### PR TITLE
Add routines for installing dependency from FileExchange

### DIFF
--- a/ndi-matlab-dependencies.json
+++ b/ndi-matlab-dependencies.json
@@ -10,6 +10,7 @@
 		"https://github.com/VH-lab/NDR-matlab",
 		"https://github.com/ehennestad/Catalog",
 		"https://github.com/a-ma72/mksqlite",
-		"https://github.com/Waltham-Data-Science/NDI-compress-matlabp"
-	]
+		"https://github.com/Waltham-Data-Science/NDI-compress-matlabp",
+		"fex://c519502d-d45f-4dbd-8564-df06ab49717f"
+        ]
 }


### PR DESCRIPTION
I added a function for installing dependencies from FileExchange. It should install zipped packages and matlab toolboxes, I am not aware of other cases.

For a FEX dependency, I went for the pattern fex//:<fex_submission_uuid>. Unfortunately, the uuid does not say anything about the name of the package, so it gets very opaque.

