### PR TITLE
fix to ndi.session.getprobes()

### DIFF
--- a/+ndi/+epoch/epochprobemap_daqsystem.m
+++ b/+ndi/+epoch/epochprobemap_daqsystem.m
@@ -54,7 +54,7 @@ classdef epochprobemap_daqsystem < ndi.epoch.epochprobemap
 				if numel(find(name_==sprintf('\n')))>0,
 					ndi_struct = ndi.epoch.epochprobemap_daqsystem.decode(name_);
 				elseif isfile(name_),
-					ndi_struct= vlt.file.loadStructArray(name_);
+					ndi_struct= table2struct(readtable(name_,'Delimiter','\t','FileType','text'));
 				end;
 				if isempty(ndi_struct),
 					ndi_struct = vlt.data.emptystruct('name','reference','type','devicestring','subjectstring');


### PR DESCRIPTION

Fixes a problem where getprobes would always return new ids for probes, even if they already existed (which is in error)

