### PR TITLE
Update ndi.session.dir to allow construction with no input arguments

### DIFF
--- a/+ndi/+session/dir.m
+++ b/+ndi/+session/dir.m
@@ -23,19 +23,19 @@ classdef dir < ndi.session
 			% See also: ndi.session, ndi.session.dir/GETPATH
 
 				if nargin<2,
-                    if nargin >= 1
-					    path = reference;
-                    end
+					if nargin >= 1
+						path = reference;
+					end
 					reference = 'temp';
 				end
 
-                ndi_session_dir_obj = ndi_session_dir_obj@ndi.session(reference);
-                
-                if nargin < 1 || isempty(path); return; end
-    
-                if ~isfolder(path),
-                    error(['Directory ' path ' does not exist.']);
-                end;
+				ndi_session_dir_obj = ndi_session_dir_obj@ndi.session(reference);
+
+				if nargin < 1 || isempty(path); return; end
+
+				if ~isfolder(path),
+					error(['Directory ' path ' does not exist.']);
+				end;
 
 				ndi_session_dir_obj.path = char(path); % Ensure type is character vector
 

--- a/+ndi/+session/dir.m
+++ b/+ndi/+session/dir.m
@@ -23,16 +23,20 @@ classdef dir < ndi.session
 			% See also: ndi.session, ndi.session.dir/GETPATH
 
 				if nargin<2,
-					path = reference;
-					ref = 'temp';
+                    if nargin >= 1
+					    path = reference;
+                    end
+					reference = 'temp';
 				end
 
-				if ~exist(path,'dir'),
-					error(['Directory ' path ' does not exist.']);
-				end;
-
-				ndi_session_dir_obj = ndi_session_dir_obj@ndi.session(reference);
+                ndi_session_dir_obj = ndi_session_dir_obj@ndi.session(reference);
                 
+                if nargin < 1 || isempty(path); return; end
+    
+                if ~isfolder(path),
+                    error(['Directory ' path ' does not exist.']);
+                end;
+
 				ndi_session_dir_obj.path = char(path); % Ensure type is character vector
 
 				should_we_try_to_read_from_database = 1;


### PR DESCRIPTION
Allows the use of array expansion of class objects as described here in the **"No Input Argument Constructor Requirement section"**:

https://se.mathworks.com/help/matlab/matlab_oop/class-constructor-methods.html#btn2kiy