### PR TITLE
Make some session properties transient

### DIFF
--- a/+ndi/session.m
+++ b/+ndi/session.m
@@ -4,10 +4,12 @@ classdef session < handle % & ndi.documentservice & % ndi.ido Matlab does not al
     properties (GetAccess=public, SetAccess = protected)
         reference         % A string reference for the session
         identifier        % A unique identifier
+    end
+    properties (GetAccess=public, SetAccess = protected, Transient)
         syncgraph         % An ndi.time.syncgraph object related to this session
         cache             % An ndi.cache object for the session's use
     end
-    properties (GetAccess=protected, SetAccess = protected)
+    properties (GetAccess=protected, SetAccess = protected, Transient)
         database          % An ndi.database associated with this session
     end
     methods


### PR DESCRIPTION
NDI does not have a workflow for saving session objects, but if a session object were to be saved, I dont think the `syncgraph`, `cache` or `database` properties should be saved, so the properties should have a Transient attribute