### PR TITLE
Dabrowska session maker

### DIFF
--- a/+ndi/+dataset/dir.m
+++ b/+ndi/+dataset/dir.m
@@ -51,4 +51,29 @@ classdef dir < ndi.dataset
             end;
         end; % dir(), creator
     end; % methods
+
+    methods (Static)
+        function dataset_erase(ndi_dataset_dir_obj, areyousure)
+            % DATABASE_ERASE - deletes the entire session database folder
+            %
+            % DATABASE_ERASE(NDI_DATASET_DIR_OBJ, AREYOUSURE)
+            %
+            %   Deletes the session in the database.
+            %
+            % Use with care. If AREYOUSURE is 'yes' then the
+            % function will proceed. Otherwise, it will not.
+            arguments
+                ndi_dataset_dir_obj {mustBeA(ndi_dataset_dir_obj,'ndi.session.dir')}
+                areyousure (1,:) char = 'no';
+            end
+
+            if strcmpi(areyousure,'yes')
+                rmdir(fullfile(ndi_dataset_dir_obj.path,'.ndi'),'s'); % remove database folder
+            else
+                disp('Not erasing session directory folder because user did not indicate they sure.');
+            end
+            delete(ndi_dataset_dir_obj);
+
+        end % dataset_erase()
+    end % methods (Static)
 end

--- a/+ndi/+file/navigator.m
+++ b/+ndi/+file/navigator.m
@@ -72,7 +72,7 @@ classdef navigator < ndi.ido & ndi.epoch.epochset.param & ndi.documentservice & 
 
             if ~isempty(session_),
                 if ~isa(session_,'ndi.session'),
-                    error(['experiement must be an ndi.session object']);
+                    error(['experiment must be an ndi.session object']);
                 else,
                     obj.session= session_;
                 end;

--- a/+ndi/+session/dir.m
+++ b/+ndi/+session/dir.m
@@ -193,7 +193,30 @@ classdef dir < ndi.session
                     exists = true;
                 end
             end
-        end
-    end
+        end % exists
+
+        function database_erase(ndi_session_dir_obj, areyousure)
+            % DATABASE_ERASE - deletes the entire session database folder
+            %
+            % DATABASE_ERASE(NDI_SESSION_DIR_OBJ, AREYOUSURE)
+            %
+            %   Deletes the session in the database.
+            %
+            % Use with care. If AREYOUSURE is 'yes' then the
+            % function will proceed. Otherwise, it will not.
+            arguments
+                ndi_session_dir_obj {mustBeA(ndi_session_dir_obj,'ndi.session.dir')}
+                areyousure (1,:) char = 'no';
+            end
+
+            if strcmpi(areyousure,'yes')
+                rmdir(fullfile(ndi_session_dir_obj.path,'.ndi'),'s'); % remove database folder
+            else
+                disp('Not erasing session directory folder because user did not indicate they sure.');
+            end
+            delete(ndi_session_dir_obj);
+        end % database_erase()
+
+    end % methods (Static)
 
 end % classdef

--- a/+ndi/+session/dir.m
+++ b/+ndi/+session/dir.m
@@ -183,4 +183,17 @@ classdef dir < ndi.session
         end; % creator_args()
     end; % methods
 
+    methods (Static)
+        function exists = exists(path)
+            exists = false;
+            files = dir(path);
+            if any(contains({files(:).name},'.ndi'))
+                files = dir(fullfile(path,'.ndi'));
+                if any(contains({files(:).name},'reference.txt'))
+                    exists = true;
+                end
+            end
+        end
+    end
+
 end % classdef

--- a/+ndi/+session/sessiontable.m
+++ b/+ndi/+session/sessiontable.m
@@ -37,7 +37,7 @@ classdef sessiontable
             fname = ndi.session.sessiontable.localtablefilename();
             if isfile(fname),
                 try,
-                    t = vlt.file.loadStructArray(fname);
+                    t = table2struct(readtable(fname,'Delimiter','tab'))';
                     if ~isfield(t,'path'),
                         error(['path is a required field.']);
                     end;

--- a/+ndi/+setup/+NDIMaker/sessionMaker.m
+++ b/+ndi/+setup/+NDIMaker/sessionMaker.m
@@ -5,134 +5,183 @@ classdef sessionMaker < handle % Using handle class for reference behavior (obje
     % needed to potentially create NDI session objects.
 
     properties (Access = public)
+        path
+        variableTable               % Table holding SessionRef and SessionPath variables to define each session
         sessions                    % Cell array intended to hold ndi.session.dir objects created later. Initialized empty.
-        fileManifest                % Cell array of file paths being examined. Set via setManifest.
-        dataLocationVariableRules   % Struct array defining rules for extracting variables from paths using processFileManifest. Must be set externally.
-        dataLocationVariables       % Struct containing extracted variable names and values, populated by computeDataLocationVariables.
-        DaqSystems                  % Struct array describing DAQ systems. Expected fields: 'daqReader', 'fileNavigator'. Must be set externally.
+        tableInd                    % Array of indices relating the sessions to rows in the variableTable
+        daqSystems                  % Struct array describing DAQ systems. Expected fields: 'daqReader', 'fileNavigator'. Must be set externally.
     end
 
     methods
-        function obj = sessionMaker()
+        function obj = sessionMaker(path,variableTable,options)
             % SESSIONMAKER Constructor for the sessionMaker class
-            % Initializes properties to default empty values suitable for their types.
-
-            obj.sessions = {}; % Initialize as empty cell array, ready to hold session objects
-            obj.fileManifest = {}; % Initialize as empty cell array
-            obj.dataLocationVariableRules = struct([]); % Initialize as empty struct array
-            % Initialize matching the expected output structure of processFileManifest
-            obj.dataLocationVariables = struct('names',{{}},'values',{{}});
-            % Initialize empty struct array with the specified fields
-            obj.DaqSystems = struct('daqReader', {}, 'fileNavigator', {});
-        end
-
-        function setManifest(obj, fileManifest, options)
-            % SETMANIFEST Sets the file manifest property and optionally trims a relative path prefix.
-            %
-            % Args:
-            %   obj (ndi.setup.NDIMaker.sessionMaker): The object instance.
-            %   fileManifest (cell vector): A cell array of strings (or char arrays),
-            %                                where each element is a relative file path.
-            %
-            % Optional Name-Value Args:
-            %   relativePathTrim (char vector | string): A prefix string to remove from the beginning
-            %                                            of each path in fileManifest. Defaults to ''.
-
+            % Initializes properties to default empty values suitable for 
+            % their types and creates sessions.
             arguments
-                obj                       (1,1) ndi.setup.NDIMaker.sessionMaker % Ensure it's operating on a valid object instance
-                fileManifest              (:,1) cell {mustBeVector, mustBeText} % Column cell vector of text
-                options.relativePathTrim  (1,:) {mustBeTextScalarOrCharVector} = '' % Allow char row vector or string scalar, default empty
+                path (1,:) char {mustBeFolder}
+                variableTable table
+                options.Overwrite logical = false;
             end
 
-            originalManifest = fileManifest; % Keep a copy of the input
+            obj.path = path;
+            obj.variableTable = variableTable;
+            
+            % Find which rows of the variable table are valid for sessions
+            % (i.e. valid SessionRef with a .mat file)
+            nanInd = cellfun(@(sr) any(isnan(sr)), variableTable.SessionRef);
+            matInd = cellfun(@(sr) ~any(isnan(sr)), variableTable.IsExpMatFile);
+            validInd = find(~nanInd & matInd);
+            [sessionRefs,sessionInd,tableInd] = unique(variableTable.SessionRef(validInd));
+            sessionInd = validInd(sessionInd);
+            obj.tableInd = nan(height(variableTable),1);
+            obj.tableInd(validInd) = tableInd;
 
-            % --- Apply relativePathTrim if provided ---
-            prefixToTrim = options.relativePathTrim;
-            % Ensure prefix is a char vector for consistent processing
-            if isstring(prefixToTrim)
-                prefixChar = char(prefixToTrim);
-            else
-                prefixChar = prefixToTrim; % Assume it's already char
-            end
-
-            if ~isempty(prefixChar)
-                prefixLen = length(prefixChar);
-                processedManifest = cell(size(originalManifest)); % Preallocate output
-                for k = 1:numel(originalManifest)
-                    originalPath = originalManifest{k};
-                    % Ensure path is char for comparison/indexing
-                    if ~ischar(originalPath)
-                       originalPath = char(originalPath);
+            % Create sessions (if not already created)
+            obj.sessions = cell(size(sessionRefs));
+            for i = 1:numel(sessionRefs)
+                sessionPath = fullfile(path,variableTable.SessionPath{sessionInd(i)});
+                if ndi.session.dir.exists(sessionPath)
+                    obj.sessions{i} = ndi.session.dir(sessionPath);
+                    if options.Overwrite
+                        % Delete existing session and create new one
+                        obj.sessions{i}.database_erase;
+                        obj.sessions{i} = ndi.session.dir(sessionRefs{i},sessionPath);
                     end
-
-                    processedManifest{k} = originalPath; % Default: keep original path
-                    originalPathLen = length(originalPath);
-
-                    % Check if path is long enough AND starts with the prefix
-                    if originalPathLen >= prefixLen && strncmp(originalPath, prefixChar, prefixLen)
-                        % It starts with the prefix
-                        if originalPathLen > prefixLen
-                            % Extract the rest of the path
-                            processedManifest{k} = originalPath(prefixLen+1:end);
-                        else
-                            % Prefix matches the entire path -> Result is empty char
-                            processedManifest{k} = '';
-                            warning('sessionMaker:setManifest:PrefixIsFullPath', ...
-                                    'The prefix "%s" matches the entire path "%s". Resulting path is empty.', ...
-                                    prefixChar, originalPath);
-                        end
-                    % else: Path doesn't start with prefix or is shorter, keep original (default already set)
-                    end
+                else
+                    obj.sessions{i} = ndi.session.dir(sessionRefs{i},sessionPath);
                 end
-                obj.fileManifest = processedManifest; % Store the processed manifest
-            else
-                obj.fileManifest = originalManifest; % Store the original manifest if no prefix provided
+                mksqlite('close')
             end
-             % --- End of prefix processing ---
+
+            % Intialize daq system variable
+            obj.daqSystems = struct('daqReader', {}, 'fileNavigator', {});
         end
 
-        function computeDataLocationVariables(obj)
-            % COMPUTEDATALOCATIONVARIABLES Extracts variables from file paths.
-            %   Runs the external function 'processFileManifest' using the object's
-            %   'fileManifest' and 'dataLocationVariableRules' properties.
-            %   Stores the resulting structure in the 'dataLocationVariables' property.
-            %   Requires 'processFileManifest.m' to be on the MATLAB path.
+        function [sessions,ind] = sessionIndices(obj)
+            %SESSIONINDICES returns the session array and indices of the
+            %   variableTable corresponding to those sessions
 
-            % --- Input Validation ---
-            if isempty(obj.fileManifest)
-                error('sessionMaker:computeDataLocationVariables:NoManifest', ...
-                      'The ''fileManifest'' property is empty. Call setManifest() first.');
-            end
-            if isempty(obj.dataLocationVariableRules) || ~isstruct(obj.dataLocationVariableRules)
-                error('sessionMaker:computeDataLocationVariables:NoRules', ...
-                      'The ''dataLocationVariableRules'' property is empty or not a struct array. Ensure it is set correctly before calling this method.');
-            end
+            sessions = obj.sessions;
+            ind = obj.tableInd;
+        end
 
-            % --- Check for external function dependency ---
-            if isempty(which('processFileManifest'))
-                error('sessionMaker:computeDataLocationVariables:MissingFunction',...
-                      'The required function ''processFileManifest.m'' was not found on the MATLAB path.');
-            end
-
-            % --- Execute processing ---
-            try
-                % Call the external function using the object's properties
-                fprintf('Computing data location variables...\n'); % Optional progress message
-                extractedData = processFileManifest(obj.fileManifest, obj.dataLocationVariableRules);
-
-                % Store the results in the object's property
-                obj.dataLocationVariables = extractedData;
-                fprintf('... Computation complete. Results stored in dataLocationVariables.\n'); % Optional completion message
-
-            catch ME
-                warning('sessionMaker:computeDataLocationVariables:ExecutionError', ...
-                        'An error occurred while running processFileManifest: %s', ME.message);
-                % Display stack trace for debugging
-                disp(ME.getReport);
-                % Rethrow the error to halt execution and indicate failure clearly
-                rethrow(ME);
+        function addDaqSystem(obj,daqName,reader,navigator)
+            daq_system = ndi.daq.system.mfdaq(daqName, navigator, reader);
+            for i = 1:numel(obj.sessions)
+                if ~isempty(obj.sessions{i}.daqsystem_load)
+                    obj.sessions{i}.daqsystem_clear();
+                end
+                obj.sessions{i}.daqsystem_add(daq_system);
             end
         end
+
+        % function setManifest(obj, fileManifest, options)
+        %     % SETMANIFEST Sets the file manifest property and optionally trims a relative path prefix.
+        %     %
+        %     % Args:
+        %     %   obj (ndi.setup.NDIMaker.sessionMaker): The object instance.
+        %     %   fileManifest (cell vector): A cell array of strings (or char arrays),
+        %     %                                where each element is a relative file path.
+        %     %
+        %     % Optional Name-Value Args:
+        %     %   relativePathTrim (char vector | string): A prefix string to remove from the beginning
+        %     %                                            of each path in fileManifest. Defaults to ''.
+        % 
+        %     arguments
+        %         obj                       (1,1) ndi.setup.NDIMaker.sessionMaker % Ensure it's operating on a valid object instance
+        %         fileManifest              (:,1) cell {mustBeVector, mustBeText} % Column cell vector of text
+        %         options.relativePathTrim  (1,:) {mustBeTextScalarOrCharVector} = '' % Allow char row vector or string scalar, default empty
+        %     end
+        % 
+        %     originalManifest = fileManifest; % Keep a copy of the input
+
+        %     % --- Apply relativePathTrim if provided ---
+        %     prefixToTrim = options.relativePathTrim;
+        %     % Ensure prefix is a char vector for consistent processing
+        %     if isstring(prefixToTrim)
+        %         prefixChar = char(prefixToTrim);
+        %     else
+        %         prefixChar = prefixToTrim; % Assume it's already char
+        %     end
+        % 
+        %     if ~isempty(prefixChar)
+        %         prefixLen = length(prefixChar);
+        %         processedManifest = cell(size(originalManifest)); % Preallocate output
+        %         for k = 1:numel(originalManifest)
+        %             originalPath = originalManifest{k};
+        %             % Ensure path is char for comparison/indexing
+        %             if ~ischar(originalPath)
+        %                originalPath = char(originalPath);
+        %             end
+        % 
+        %             processedManifest{k} = originalPath; % Default: keep original path
+        %             originalPathLen = length(originalPath);
+        % 
+        %             % Check if path is long enough AND starts with the prefix
+        %             if originalPathLen >= prefixLen && strncmp(originalPath, prefixChar, prefixLen)
+        %                 % It starts with the prefix
+        %                 if originalPathLen > prefixLen
+        %                     % Extract the rest of the path
+        %                     processedManifest{k} = originalPath(prefixLen+1:end);
+        %                 else
+        %                     % Prefix matches the entire path -> Result is empty char
+        %                     processedManifest{k} = '';
+        %                     warning('sessionMaker:setManifest:PrefixIsFullPath', ...
+        %                             'The prefix "%s" matches the entire path "%s". Resulting path is empty.', ...
+        %                             prefixChar, originalPath);
+        %                 end
+        %             % else: Path doesn't start with prefix or is shorter, keep original (default already set)
+        %             end
+        %         end
+        %         obj.fileManifest = processedManifest; % Store the processed manifest
+        %     else
+        %         obj.fileManifest = originalManifest; % Store the original manifest if no prefix provided
+        %     end
+        %      % --- End of prefix processing ---
+        % end
+        % 
+        % function computeDataLocationVariables(obj)
+        %     % COMPUTEDATALOCATIONVARIABLES Extracts variables from file paths.
+        %     %   Runs the external function 'processFileManifest' using the object's
+        %     %   'fileManifest' and 'dataLocationVariableRules' properties.
+        %     %   Stores the resulting structure in the 'dataLocationVariables' property.
+        %     %   Requires 'processFileManifest.m' to be on the MATLAB path.
+        % 
+        %     % --- Input Validation ---
+        %     if isempty(obj.fileManifest)
+        %         error('sessionMaker:computeDataLocationVariables:NoManifest', ...
+        %               'The ''fileManifest'' property is empty. Call setManifest() first.');
+        %     end
+        %     if isempty(obj.dataLocationVariableRules) || ~isstruct(obj.dataLocationVariableRules)
+        %         error('sessionMaker:computeDataLocationVariables:NoRules', ...
+        %               'The ''dataLocationVariableRules'' property is empty or not a struct array. Ensure it is set correctly before calling this method.');
+        %     end
+        % 
+        %     % --- Check for external function dependency ---
+        %     if isempty(which('processFileManifest'))
+        %         error('sessionMaker:computeDataLocationVariables:MissingFunction',...
+        %               'The required function ''processFileManifest.m'' was not found on the MATLAB path.');
+        %     end
+        % 
+        %     % --- Execute processing ---
+        %     try
+        %         % Call the external function using the object's properties
+        %         fprintf('Computing data location variables...\n'); % Optional progress message
+        %         extractedData = processFileManifest(obj.fileManifest, obj.dataLocationVariableRules);
+        % 
+        %         % Store the results in the object's property
+        %         obj.dataLocationVariables = extractedData;
+        %         fprintf('... Computation complete. Results stored in dataLocationVariables.\n'); % Optional completion message
+        % 
+        %     catch ME
+        %         warning('sessionMaker:computeDataLocationVariables:ExecutionError', ...
+        %                 'An error occurred while running processFileManifest: %s', ME.message);
+        %         % Display stack trace for debugging
+        %         disp(ME.getReport);
+        %         % Rethrow the error to halt execution and indicate failure clearly
+        %         rethrow(ME);
+        %     end
+        % end
 
         % --- Placeholder for other potential methods ---
         % function addDaqSystem(obj, reader, navigator)

--- a/+ndi/+setup/+conv/+dabrowska/working.m
+++ b/+ndi/+setup/+conv/+dabrowska/working.m
@@ -14,29 +14,13 @@ jsonPath = fullfile(myDir,'tools/NDI-matlab/+ndi/+setup/+conv/+dabrowska/dabrows
 j = jsondecode(fileread(jsonPath));
 variableTable = ndi.setup.conv.datalocation.processFileManifest(fileList,...
     j,'relativePathPrefix','Dabrowska/');
-variableTable = variableTable(1:100,:);
+% variableTable = variableTable(100:200,:);
 
 %% Create NDI sessions
-S = ndi.setup.NDIMaker.sessionMaker(myPath,variableTable);
+S = ndi.setup.NDIMaker.sessionMaker(myPath,variableTable,...
+    'NonNaNVariableNames','IsExpMatFile','Overwrite',true);
 [sessionArray,variableTable.sessionInd] = S.sessionIndices;
 
 %% Add DAQ system
-navigator = ndi.file.navigator(sessionArray{1}, ...
-    {'#.mat', '#.epochprobemap.txt'}, ...
-    'ndi.epoch.epochprobemap_daqsystem','#.epochprobemap.txt');
-reader = ndi.daq.reader.mfdaq.ndr('dabrowska');
-daqName = 'dabrowska_mat';
-S.addDaqSystem(daqName,reader,navigator);
-
-%% hangers on
-
-L1 = (cellfun(@(x) ~isequaln(x,NaN), t.IsExpMatFile)) & cellfun(@(x) isequaln(x,NaN), t.BathConditionString);
-
-
- % need to add table constant elements, join 
- % epochprobmap_daqsystem: dabrowska_intracell
- % probes: dabrowska_current: patch-I
- %    dabrowska_voltage: patch-V
- %    dabrowska_stimulator: stimulator
-
-bath_background
+labName = 'dabrowskalab';
+S.addDaqSystem(labName,'Overwrite',true)

--- a/+ndi/+setup/+conv/+dabrowska/working.m
+++ b/+ndi/+setup/+conv/+dabrowska/working.m
@@ -1,20 +1,34 @@
+% Set paths
+myDir = '/Users/jhaley/Documents/MATLAB';
+myPath = fullfile(myDir,'data','Dabrowska');
 
+% Get files
+[dirList,isDir] = vlt.file.manifest(myPath);
+fileList = dirList(~isDir);
+% include = ~contains(fileList,'/._') & ~startsWith(fileList,'._') & ...
+%     ~contains(fileList,'.DS_Store'); 
+% fileList = fileList(include);
 
-myPath = '/Users/vanhoosr/Library/CloudStorage/GoogleDrive-steve@walthamdatascience.com/Shared drives/Dabrowska';
+% Get variable table
+jsonPath = fullfile(myDir,'tools/NDI-matlab/+ndi/+setup/+conv/+dabrowska/dabrowskaDataLocation.json');
+j = jsondecode(fileread(jsonPath));
+variableTable = ndi.setup.conv.datalocation.processFileManifest(fileList,...
+    j,'relativePathPrefix','Dabrowska/');
+variableTable = variableTable(1:100,:);
 
+%% Create NDI sessions
+S = ndi.setup.NDIMaker.sessionMaker(myPath,variableTable);
+[sessionArray,variableTable.sessionInd] = S.sessionIndices;
 
-[fileList,isDir] = vlt.file.manifest(pwd);
-filefileList = fileList(~isDir);
+%% Add DAQ system
+navigator = ndi.file.navigator(sessionArray{1}, ...
+    {'#.mat', '#.epochprobemap.txt'}, ...
+    'ndi.epoch.epochprobemap_daqsystem','#.epochprobemap.txt');
+reader = ndi.daq.reader.mfdaq.ndr('dabrowska');
+daqName = 'dabrowska_mat';
+S.addDaqSystem(daqName,reader,navigator);
 
-incl = []; for i=1:numel(filefileList), if ~contains(filefileList{i},'/._'), incl(end+1) = i; end; end
-filefileList = filefileList(incl);
-incl = []; for i=1:numel(filefileList), if ~startsWith(filefileList{i},'._'), incl(end+1) = i; end; end
-filefileList = filefileList(incl);
-
-t = ndi.setup.conv.datalocation.processFileManifest(filefileList,j,'relativePathPrefix','Dabrowska/');
-
-
-  % hangers on
+%% hangers on
 
 L1 = (cellfun(@(x) ~isequaln(x,NaN), t.IsExpMatFile)) & cellfun(@(x) isequaln(x,NaN), t.BathConditionString);
 

--- a/+ndi/database.m
+++ b/+ndi/database.m
@@ -213,26 +213,6 @@ classdef database
             end;
         end % clear
 
-        function erase(ndi_database_obj, areyousure)
-            % ERASE - deletes the entire ndi.database folder
-            %
-            % ERASE(NDI_DATABASE_OBJ, [AREYOUSURE])
-            %
-            % Use with care. If AREYOUSURE is 'yes' then the
-            % function will proceed. Otherwise, it will not.
-            %
-            % See also: ndi.database/CLEAR, ndi.database/REMOVE 
-
-            if nargin<2,
-                areyousure = 'no';
-            end;
-            if strcmpi(areyousure,'Yes')
-                rmdir(ndi_database_obj.path,'s'); % remove database folder
-            else,
-                disp('Not erasing database folder because user did not indicate they sure.');
-            end;
-        end % erase
-
         function [ndi_document_objs] = search(ndi_database_obj, searchparams)
             % SEARCH - search for an ndi.document from an ndi.database
             %

--- a/+ndi/database.m
+++ b/+ndi/database.m
@@ -209,9 +209,29 @@ classdef database
                     ndi_database_obj.remove(ids{i}); % remove the entry
                 end
             else,
-                disp(['Not clearing because user did not indicate he/she is sure.']);
+                disp('Not clearing because user did not indicate they are sure.');
             end;
         end % clear
+
+        function erase(ndi_database_obj, areyousure)
+            % ERASE - deletes the entire ndi.database folder
+            %
+            % ERASE(NDI_DATABASE_OBJ, [AREYOUSURE])
+            %
+            % Use with care. If AREYOUSURE is 'yes' then the
+            % function will proceed. Otherwise, it will not.
+            %
+            % See also: ndi.database/CLEAR, ndi.database/REMOVE 
+
+            if nargin<2,
+                areyousure = 'no';
+            end;
+            if strcmpi(areyousure,'Yes')
+                rmdir(ndi_database_obj.path,'s'); % remove database folder
+            else,
+                disp('Not erasing database folder because user did not indicate they sure.');
+            end;
+        end % erase
 
         function [ndi_document_objs] = search(ndi_database_obj, searchparams)
             % SEARCH - search for an ndi.document from an ndi.database

--- a/+ndi/session.m
+++ b/+ndi/session.m
@@ -341,6 +341,19 @@ classdef session < handle % & ndi.documentservice & % ndi.ido Matlab does not al
             ndi_session_obj.database.clear(areyousure);
         end; % database_clear()
 
+        function database_erase(ndi_session_obj, areyousure)
+            % DATABASE_ERASE - deletes the entire database folder
+            %
+            % DATABASE_ERASE(NDI_SESSION_OBJ, AREYOUSURE)
+            %
+            %   Deletes the session in the database.
+            %
+            % Use with care. If AREYOUSURE is 'yes' then the
+            % function will proceed. Otherwise, it will not.
+            %
+            ndi_session_obj.database.erase(areyousure);
+        end; % database_erase()
+
         function [b,errmsg] = validate_documents(ndi_session_obj, document)
             % VALIDATE_DOCUMENTS - validate whether documents belong to a session
             %

--- a/+ndi/session.m
+++ b/+ndi/session.m
@@ -341,19 +341,6 @@ classdef session < handle % & ndi.documentservice & % ndi.ido Matlab does not al
             ndi_session_obj.database.clear(areyousure);
         end; % database_clear()
 
-        function database_erase(ndi_session_obj, areyousure)
-            % DATABASE_ERASE - deletes the entire database folder
-            %
-            % DATABASE_ERASE(NDI_SESSION_OBJ, AREYOUSURE)
-            %
-            %   Deletes the session in the database.
-            %
-            % Use with care. If AREYOUSURE is 'yes' then the
-            % function will proceed. Otherwise, it will not.
-            %
-            ndi_session_obj.database.erase(areyousure);
-        end; % database_erase()
-
         function [b,errmsg] = validate_documents(ndi_session_obj, document)
             % VALIDATE_DOCUMENTS - validate whether documents belong to a session
             %


### PR DESCRIPTION
`obj = sessionMaker(path,variableTable,options)` and `[sessions,ind] = sessionIndices(obj)` seem to be working. `addDaqSystem(obj,daqName,reader,navigator)` does not yet work. I am still working on this and need to add/edit documentation to several of the functions that I edited. However, I think it would be helpful to check-in about some of the following:

The `variableTable` produced by `ndi.setup.conv.datalocation.processFileManifest` does not maintain the full path. I added an input to `sessionMaker()` to circumvent this, but would it be better to have `processFileManifest` return the full path somewhere in the table?

Is there a strong reasoning behind returning `NaN` values for invalid `SessionRefs`? This creates extra work when processing unique values of `variableTable.SessionRef`. I’ve done this and it works fine, but maybe it would be better to leave these rows as empty char arrays and have an additional logical variable in the table that denotes valid sessions?

It seems a little strange to me that `variableTable.IsExpMatFile` is a cell array rather than just a logical denoting if the file extension is .mat.

I could not figure out a way to delete the session to create a new `sessionRef` (if needing to overwrite). I added `erase` functions to `ndi.database` and `ndi.session` that delete the entire .ndi folder allowing this to occur. Please let me know if there is a better approach.

I ran into an issue with `mksqlite` at ~19 sessions in. I got the error:
```
Error using mksqlite
no free database handle available
```
My current work around is to run `mksqlite('close')` after the creation of each session. This seems to solve the problem, but let me know if there is a better way.

From my understanding, a `navigator = ndi.file.navigator` requires association with a particular session. How do we want to therefore pass the navigator to the function addDaqSystem?