### PR TITLE
Fix bug in PathConstants when multiple calculator document locations are available

### DIFF
--- a/+ndi/+common/PathConstants.m
+++ b/+ndi/+common/PathConstants.m
@@ -103,7 +103,7 @@ classdef PathConstants
 
             pathList = cell(1, numel(d));
             for i = 1:numel(d)
-                pathList{i} = fullfile(d{i}, 'ndi_common', key);
+                pathList{i} = fullfile(d{i}, 'ndi_common', char(key));
                 % addpath(d{i})  % Matlab hangs for me here; it doesn't like this being called from a constant definition
                 % error: `Unable to determine if 'ndi.common.PathConstants.CommonFolder' is a function.`...
                 %        ` The MATLAB Path or current folder changed too many times during the search.`


### PR DESCRIPTION
Make sure the list of path names for calculator document definitions is a cell array or chars, not a cell array of strings. 

This fixes a bug which would cause the following error if multiple calculator repositories are on MATLAB's search path:

```MATLAB
    ---------
    Error ID:
    ---------
    'MATLAB:dir:invalidInputType'
    --------------
    Error Details:
    --------------
    Error using dir
    Name must be a text scalar.
    
    Error in did.document.readjsonfilelocation (line 783)
                        files = dir([mypaths{j} filesep '**']);
    
    Error in ndi.document.readblankdefinition (line 845)
                t = did.document.readjsonfilelocation(jsonfilelocationstring);
    
    Error in ndi.document (line 28)
                    document_properties = ndi.document.readblankdefinition(document_type);
    
    Error in ndi.session.dir (line 98)
                    g = ndi.document('session','session.reference',ndi_session_dir_obj.reference) + ...
```
    