### PR TITLE
Fix broken links in documentation

### DIFF
--- a/docs/NDI-matlab/faq.md
+++ b/docs/NDI-matlab/faq.md
@@ -2,11 +2,11 @@
 
 ## Q: Can I use NDI to analyze data recorded in any format?
 
-**A**: Yes. The NDI system includes pieces of code called [`ndi.daq.reader` objects](https://vh-lab.github.io/NDI-matlab/reference/%2Bndi/%2Bdaq/reader.m/) which interpret data recorded with different acquisition devices. Each `ndi.daq.reader` is specific to a particular device, and `ndi.daq.reader` objects [already exist](https://vh-lab.github.io/NDI-matlab/reference/%2Bndi/%2Bdaq/%2Breader/mfdaq.m/) for devices by several neuroscience software manufacturers.
+**A**: Yes. The NDI system includes pieces of code called [`ndi.daq.reader` objects](https://vh-lab.github.io/NDI-matlab/NDI-matlab/reference/%2Bndi/%2Bdaq/reader.m/) which interpret data recorded with different acquisition devices. Each `ndi.daq.reader` is specific to a particular device, and `ndi.daq.reader` objects [already exist](https://vh-lab.github.io/NDI-matlab/NDI-matlab/reference/%2Bndi/%2Bdaq/%2Breader/mfdaq.m/) for devices by several neuroscience software manufacturers.
 
 ## Q: Can I use NDI if my lab builds our own devices and measuring tools?
 
-**A**: Yes. You will need to write one piece of code - an [`ndi.daq.reader` object](https://vh-lab.github.io/NDI-matlab/reference/%2Bndi/%2Bdaq/reader.m/) - for each original DAQ system you use. Possibly, you will also need to create an `ndi.daq.metadatareader to read metadata, such as stimulus information for custom stimuli. Once these are created, your data can be read and analyzed with NDI.
+**A**: Yes. You will need to write one piece of code - an [`ndi.daq.reader` object](https://vh-lab.github.io/NDI-matlab/NDI-matlab/reference/%2Bndi/%2Bdaq/reader.m/) - for each original DAQ system you use. Possibly, you will also need to create an `ndi.daq.metadatareader to read metadata, such as stimulus information for custom stimuli. Once these are created, your data can be read and analyzed with NDI.
 
 ## Q: Do I need to change the way my lab organizes our data files in order to use NDI?
 

--- a/docs/NDI-matlab/oldREADME.md
+++ b/docs/NDI-matlab/oldREADME.md
@@ -3,7 +3,7 @@ Neuroscience Data Interface - A means of specifying and accessing neuroscience d
 
 Available at https://github.com/VH-Lab/NDI-matlab
 
-Installation instructions: https://vh-lab.github.io/NDI-matlab/installation/
+Installation instructions: https://vh-lab.github.io/NDI-matlab/NDI-matlab/installation/
 
 Notes for manual installers: 
 
@@ -13,7 +13,7 @@ It is recommended that the developer also install vhlab_vhtools, available at ht
 
 It is assumed that the function `ndi_Init.m` is run at startup. Please add this to your `startup.m` file. (If you use the http://github.com/VH-Lab/vhlab_vhtools distribution, it will be run automatically.)
 
-Documentation is at https://vh-lab.github.io/NDI-matlab/
+Documentation is at https://vh-lab.github.io/NDI-matlab/NDI-matlab/
 
 Still in early development
 

--- a/docs/NDI-matlab/oldREADME.md
+++ b/docs/NDI-matlab/oldREADME.md
@@ -13,7 +13,7 @@ It is recommended that the developer also install vhlab_vhtools, available at ht
 
 It is assumed that the function `ndi_Init.m` is run at startup. Please add this to your `startup.m` file. (If you use the http://github.com/VH-Lab/vhlab_vhtools distribution, it will be run automatically.)
 
-Documentation is at https://vh-lab.github.io/NDI-matlab/NDI-matlab/
+Documentation is at https://vh-lab.github.io/NDI-matlab/
 
 Still in early development
 

--- a/docs/NDI-matlab/tutorials/analyzing_first_physiology_experiment/1_example_dataset.md
+++ b/docs/NDI-matlab/tutorials/analyzing_first_physiology_experiment/1_example_dataset.md
@@ -1,11 +1,11 @@
 # Tutorial 2: Analyzing your first electrophysiology experiment with NDI
 
-This is a beginner's tutorial for NDI. This tutorial is designed for users who have some basic familiarity with coding or Matlab. If you're a Matlab and coding newbie, please use [Tutorial 3.1, the detailed version](https://vh-lab.github.io/NDI-matlab/tutorials/analyzing_first_physiology_experiment_detailed/1_example_dataset/).
+This is a beginner's tutorial for NDI. This tutorial is designed for users who have some basic familiarity with coding or Matlab. If you're a Matlab and coding newbie, please use [Tutorial 3.1, the detailed version](https://vh-lab.github.io/NDI-matlab/NDI-matlab/tutorials/analyzing_first_physiology_experiment_detailed/1_example_dataset/).
 
 ## 2.1: Reading an example dataset
 
 We will start with learning to read an example dataset into NDI. We assume you have already
-[installed NDI](https://vh-lab.github.io/NDI-matlab/installation/) and taken the [introductory tutorial of the NDI model](https://vh-lab.github.io/NDI-matlab/tutorials/ndimodel/1_intro/). These data are available in a
+[installed NDI](https://vh-lab.github.io/NDI-matlab/NDI-matlab/installation/) and taken the [introductory tutorial of the NDI model](https://vh-lab.github.io/NDI-matlab/NDI-matlab/tutorials/ndimodel/1_intro/). These data are available in a
 compressed folder
 [here](https://drive.google.com/file/d/1j7IAeMSrH64-qIDLB5EJYUofJSdinwuU/view?usp=sharing). 
 You can put the folder anywhere, but
@@ -66,9 +66,9 @@ In this example, we have already prepared the metadata files that are necessary 
 
 First, we need to tell NDI what **probes** we have in our experiment. A **probe** is anything that measures or stimulates; one end of a probe 
 is connected to a **subject**, and the other end of a probe is connected to a data acquisition device. We tell NDI how the probe is connected by
-creating an [ndi.epoch.epochprobemap](https://vh-lab.github.io/NDI-matlab/reference/%2Bndi/%2Bepoch/epochprobemap.m/). Usually, we do this with a little
+creating an [ndi.epoch.epochprobemap](https://vh-lab.github.io/NDI-matlab/NDI-matlab/reference/%2Bndi/%2Bepoch/epochprobemap.m/). Usually, we do this with a little
 code that instructs NDI how to read this information directly from the laboratory's own file information, but in this example, we will use the
-generic [ndi.epoch.epochprobemap_daqsystem](https://vh-lab.github.io/NDI-matlab/reference/%2Bndi/%2Bdaq/%2Bmetadata/epochprobemap_daqsystem.m/) object, which reads in a simple tab-delimited text file.
+generic [ndi.epoch.epochprobemap_daqsystem](https://vh-lab.github.io/NDI-matlab/NDI-matlab/reference/%2Bndi/%2Bdaq/%2Bmetadata/epochprobemap_daqsystem.m/) object, which reads in a simple tab-delimited text file.
 
 Let's print the `probemap.txt` file for directory `t00001`:
 
@@ -103,9 +103,9 @@ data can be read directly, but here we have made another tab-delimited text file
 type (fullfile(prefix,'ts_exper1','t00001','stims.tsv'))
 ```
 
-### 2.1.4 Gaining access to the data in NDI: [ndi.session](https://vh-lab.github.io/NDI-matlab/reference/%2Bndi/session.m/) and [ndi.daq.system](https://vh-lab.github.io/NDI-matlab/reference/%2Bndi/%2Bdaq/system.m/) objects
+### 2.1.4 Gaining access to the data in NDI: [ndi.session](https://vh-lab.github.io/NDI-matlab/NDI-matlab/reference/%2Bndi/session.m/) and [ndi.daq.system](https://vh-lab.github.io/NDI-matlab/NDI-matlab/reference/%2Bndi/%2Bdaq/system.m/) objects
 
-Now all that remains is to open the data directory as an [ndi.session](https://vh-lab.github.io/NDI-matlab/reference/%2Bndi/session.m/) object, and make [ndi.daq.system](https://vh-lab.github.io/NDI-matlab/reference/%2Bndi/%2Bdaq/system.m/) objects to read your data. We will use an [ndi.session.dir](https://vh-lab.github.io/NDI-matlab/reference/%2Bndi/%2Bsession/dir.m/) object, which allows us to read information from a directory (folder) on disk. 
+Now all that remains is to open the data directory as an [ndi.session](https://vh-lab.github.io/NDI-matlab/NDI-matlab/reference/%2Bndi/session.m/) object, and make [ndi.daq.system](https://vh-lab.github.io/NDI-matlab/NDI-matlab/reference/%2Bndi/%2Bdaq/system.m/) objects to read your data. We will use an [ndi.session.dir](https://vh-lab.github.io/NDI-matlab/NDI-matlab/reference/%2Bndi/%2Bsession/dir.m/) object, which allows us to read information from a directory (folder) on disk. 
 
 We will create a new ndi.system object by calling the constructor with the reference name we wish to give to the session and the pathname to our data:
 
@@ -127,17 +127,17 @@ S.getprobes()
 
 Unless you ran this demo before, you won't see any probes here (it will return an empty cell array). 
 
-We need to make new [ndi.daq.system](https://vh-lab.github.io/NDI-matlab/reference/%2Bndi/%2Bdaq/system.m/) objects for our data acquisition system and our stimulator. Our devices are
-multifunction data acquisition systems, so we use the [ndi.daq.system.mfdaq](https://vh-lab.github.io/NDI-matlab/reference/%2Bndi/%2Bdaq/%2Bsystem/mfdaq.m/) subtype.
+We need to make new [ndi.daq.system](https://vh-lab.github.io/NDI-matlab/NDI-matlab/reference/%2Bndi/%2Bdaq/system.m/) objects for our data acquisition system and our stimulator. Our devices are
+multifunction data acquisition systems, so we use the [ndi.daq.system.mfdaq](https://vh-lab.github.io/NDI-matlab/NDI-matlab/reference/%2Bndi/%2Bdaq/%2Bsystem/mfdaq.m/) subtype.
 
-An [ndi.daq.system](https://vh-lab.github.io/NDI-matlab/reference/%2Bndi/%2Bdaq/system.m/) object consists of three components: an
-[ndi.file.navigator](https://vh-lab.github.io/NDI-matlab/reference/%2Bndi/%2Bfile/navigator.m/) object whose job it is to find the files or
+An [ndi.daq.system](https://vh-lab.github.io/NDI-matlab/NDI-matlab/reference/%2Bndi/%2Bdaq/system.m/) object consists of three components: an
+[ndi.file.navigator](https://vh-lab.github.io/NDI-matlab/NDI-matlab/reference/%2Bndi/%2Bfile/navigator.m/) object whose job it is to find the files or
 streams associated with
-each epoch of data, an [ndi.daq.reader](https://vh-lab.github.io/NDI-matlab/reference/%2Bndi/%2Bdaq/reader.m/) object whose job it is to read the raw data from the files, and an
-[ndi.daq.metadatareader](https://vh-lab.github.io/NDI-matlab/reference/%2Bndi/%2Bdaq/metadatareader.m/) (optionally) whose
+each epoch of data, an [ndi.daq.reader](https://vh-lab.github.io/NDI-matlab/NDI-matlab/reference/%2Bndi/%2Bdaq/reader.m/) object whose job it is to read the raw data from the files, and an
+[ndi.daq.metadatareader](https://vh-lab.github.io/NDI-matlab/NDI-matlab/reference/%2Bndi/%2Bdaq/metadatareader.m/) (optionally) whose
 job it is to read any metadata associated with the epoch (such as stimulus parameter information). 
 
-First, we will build an [ndi.daq.system.mfdaq](https://vh-lab.github.io/NDI-matlab/reference/%2Bndi/%2Bdaq/%2Bsystem/mfdaq.m/) object that we will call `'ced_daqsystem'` to
+First, we will build an [ndi.daq.system.mfdaq](https://vh-lab.github.io/NDI-matlab/NDI-matlab/reference/%2Bndi/%2Bdaq/%2Bsystem/mfdaq.m/) object that we will call `'ced_daqsystem'` to
 read the electrode data from our CED SMR files.
 
 #### Code block 2.1.4.3. Type this in to Matlab:
@@ -163,7 +163,7 @@ et = ced_system.epochtable() % should see a 4 element answer
 f = ced_system.filenavigator.getepochfiles(1) % you should see the files from epoch 1, t00001
 ```
 
-Second, we will build an [ndi.daq.system.mfdaq](https://vh-lab.github.io/NDI-matlab/reference/%2Bndi/%2Bdaq/%2Bsystem/mfdaq.m/) for our visual stimulus system.
+Second, we will build an [ndi.daq.system.mfdaq](https://vh-lab.github.io/NDI-matlab/NDI-matlab/reference/%2Bndi/%2Bdaq/%2Bsystem/mfdaq.m/) for our visual stimulus system.
 
 #### Code block 2.1.4.5. Type this in to Matlab:
 
@@ -189,7 +189,7 @@ S.syncgraph_addrule(nsf);
 ```
 
 
-### 2.1.5 Opening the data in NDI: accessing probes via from [ndi.daq.system.mfdaq](https://vh-lab.github.io/NDI-matlab/reference/%2Bndi/%2Bdaq/%2Bsystem/mfdaq.m/)
+### 2.1.5 Opening the data in NDI: accessing probes via from [ndi.daq.system.mfdaq](https://vh-lab.github.io/NDI-matlab/NDI-matlab/reference/%2Bndi/%2Bdaq/%2Bsystem/mfdaq.m/)
 
 Now we can use NDI to see the probes that these daq systems can find and to access the data from those probes. Let's look at the electrode probe data first.
 
@@ -208,7 +208,7 @@ epoch_to_read = 1;
 ```
 
 You can see that probe 1 has a *name* of `ctx`, a *reference* of `1`, and it is of *type* `n-trode`, or an n-channel electrode. It has a software
-object type of [ndi.probe.timeseries.mfdaq](https://vh-lab.github.io/NDI-matlab/reference/%2Bndi/%2Bprobe/%2Btimeseries/mfdaq.m/), which simply means
+object type of [ndi.probe.timeseries.mfdaq](https://vh-lab.github.io/NDI-matlab/NDI-matlab/reference/%2Bndi/%2Bprobe/%2Btimeseries/mfdaq.m/), which simply means
 it is associated with multifunction DAQ systems and returns timeseries observations.
 Now let's read data from our probe `p_ctx1` and plot the data:
 
@@ -250,7 +250,7 @@ for i=1:numel(et), et(i), end; % display the epoch table entries
 
 Now let's read the data from our stimulator. To do this, we are going to ask NDI to read the stimulus timing information
 in the time units of our electrode probe `p_ctx`. You'll notice that when we read data from `p_ctx1`, `readtimeseries` returned
-an [ndi.time.timereference](https://vh-lab.github.io/NDI-matlab/reference/%2Bndi/%2Btime/timereference.m/) object `timeref_p_ctx1`.
+an [ndi.time.timereference](https://vh-lab.github.io/NDI-matlab/NDI-matlab/reference/%2Bndi/%2Btime/timereference.m/) object `timeref_p_ctx1`.
 Let's examine this quickly:
 
 #### Code block 2.1.5.4. Type this in to Matlab:
@@ -261,7 +261,7 @@ timeref_p_ctx1
 
 You'll see a structure with the following fields:
 
-| `timeref_p_ctx1`  | [timereference](https://vh-lab.github.io/NDI-matlab/reference/%2Bndi/%2Btime/timereference.m/) with properties |
+| `timeref_p_ctx1`  | [timereference](https://vh-lab.github.io/NDI-matlab/NDI-matlab/reference/%2Bndi/%2Btime/timereference.m/) with properties |
 | ---- | ---- |
 | referent |  `[1x1 ndi.probe.timeseries.mfdaq]` | 
 | clocktype |  `[1x1 ndi.time.clocktype]` |
@@ -295,7 +295,7 @@ data.parameters{1}
 ```
 
 Here we examined several fields of the variables `data` and `t` returned from `readtimeseries` from our
-[ndi.probe.timeseries.stimulator](https://vh-lab.github.io/NDI-matlab/reference/%2Bndi/%2Bprobe/%2Btimeseries/stimulator.m/).
+[ndi.probe.timeseries.stimulator](https://vh-lab.github.io/NDI-matlab/NDI-matlab/reference/%2Bndi/%2Bprobe/%2Btimeseries/stimulator.m/).
 
 You can see that `t` is a structure with 2 fields, `stimon` and `stimoff`. Our system kept track of when each stimulus began, but in these recordings, we did not have our data acquisition system
 keep track of when our stimulus turned off. (For later analysis, we will need to read this from the stimulus parameters.)

--- a/docs/NDI-matlab/tutorials/analyzing_first_physiology_experiment/2_theautomatedway.md
+++ b/docs/NDI-matlab/tutorials/analyzing_first_physiology_experiment/2_theautomatedway.md
@@ -2,7 +2,7 @@
 
 ## 2.2 Automating the reading of data from your rig or lab or collaborator
 
-In the previous tutorial, we reviewed the steps necessary to create [ndi.daq.system](https://vh-lab.github.io/NDI-matlab/reference/%2Bndi/%2Bdaq/system.m/) objects to read in a dataset, and
+In the previous tutorial, we reviewed the steps necessary to create [ndi.daq.system](https://vh-lab.github.io/NDI-matlab/NDI-matlab/reference/%2Bndi/%2Bdaq/system.m/) objects to read in a dataset, and
 to add the metadata that is necessary to tell NDI about the contents of each epoch. 
 
 Most labs use the same data acquisition devices and file organization schemes over and over again, and many labs also store
@@ -23,7 +23,7 @@ use the [issue tracker](https://github.com/VH-Lab/NDI-matlab/issues) to post a q
 is the biggest stress point in using NDI. The system is relatively easy to use once you are able to read your data!
 
 While there are many ways to organize code for custom setups, we have created a motif that is easy to follow. The `ndi` package
-in Matlab has a subpackage called `setup`. Here, we have placed m-files that create an [ndi.session](https://vh-lab.github.io/NDI-matlab/reference/+ndi/session.m/) with the default
+in Matlab has a subpackage called `setup`. Here, we have placed m-files that create an [ndi.session](https://vh-lab.github.io/NDI-matlab/NDI-matlab/reference/+ndi/session.m/) with the default
 settings for various labs or users. The `setup` package also has a subpackage structure that mimics the subpackage structure
 of `ndi`. In Matlab, packages are denoted by putting a `+` in the folder name:
 
@@ -58,14 +58,14 @@ vhlab now. You'll see that these directories have a few more files. It's not nec
 To import data from our lab, we created 4 Matlab files:
 
 - `+ndi/+setup/vhlab.m` - A function that builds an ndi.session object with daq systems that read from our lab's major devices.
-- `+ndi/+setup/+daq/+metadata/epochprobemap_daqsystem_vhlab.m` - A class that examines our lab's metadata files that describe the mapping between probes and data acquisition systems and returns an epochprobemap that NDI can interpret. Overrides the default [ndi.epoch.epochprobemap_daqsystem.m](https://vh-lab.github.io/NDI-matlab/reference/+ndi/%2Bepoch/epochprobemap_daqsystem.m/) class that reads the `probemap.txt` text files we saw in [Tutorial 2.1](../1_example_dataset/). 
+- `+ndi/+setup/+daq/+metadata/epochprobemap_daqsystem_vhlab.m` - A class that examines our lab's metadata files that describe the mapping between probes and data acquisition systems and returns an epochprobemap that NDI can interpret. Overrides the default [ndi.epoch.epochprobemap_daqsystem.m](https://vh-lab.github.io/NDI-matlab/NDI-matlab/reference/+ndi/%2Bepoch/epochprobemap_daqsystem.m/) class that reads the `probemap.txt` text files we saw in [Tutorial 2.1](../1_example_dataset/). 
 - `+ndi/+setup/+daq/+reader/+mfdaq/+stimulus/vhlabvisspike2.m` - A class that reads stimulus event data from our custom acquisition files.
 - `+ndi/+daq/+metadatareader/NewStimStims.m` - A class that imports stimulus metadata from our lab's open source [NewStim](https://github.com/VH-Lab/vhlab-NewStim-matlab) package. (We put it in NDI proper because it is an open source program, not intended solely for our lab.)
 
 ### 2.2.3 Creating a `setup` file.
 
 The setup file accomplishes, in an automated fashion, exactly what we did in [Tutorial 2.1](../1_example_dataset/): it 
-opens an [ndi.session](https://vh-lab.github.io/NDI-matlab/reference/+ndi/session.m/) with a particular reference name and directory path, and adds the daq systems that are necessary
+opens an [ndi.session](https://vh-lab.github.io/NDI-matlab/NDI-matlab/reference/+ndi/session.m/) with a particular reference name and directory path, and adds the daq systems that are necessary
 to read the probe data. It normally lives in `+ndi/+setup/LABORINVESTIGATORNAME.m`. We include the code here:
 
 #### Code block 2.2.3.1: Content of `+ndi/+setup/vhlab.m`. (Do not type into Matlab command line.)
@@ -104,7 +104,7 @@ S.syncgraph_addrule(n_intan2spike2);
 ```
 
 This function calls another function that we will see in a minute (`ndi.setup.daq.system.vhlab`) that actually builds the
-daq system objects that we use in our lab. At the end of this function, 2 [ndi.time.syncrules](https://vh-lab.github.io/NDI-matlab/reference/+ndi/%2Btime/syncrule.m/) are added that describe
+daq system objects that we use in our lab. At the end of this function, 2 [ndi.time.syncrules](https://vh-lab.github.io/NDI-matlab/NDI-matlab/reference/+ndi/%2Btime/syncrule.m/) are added that describe
 how synchronization is performed across our devices. If 2 or more of the same files are present in an epoch, then it is assumed
 that files are from the same underlying device and they are assumed to have the same time clock. Our custom acquisition code
 also produces a file `vhintan_intan2spike2time.txt` that has the time shift and scaling between our Intan acquisition system
@@ -114,13 +114,13 @@ in that file.
 ### 2.2.4 Creating a function that creates the daq systems for a lab
 
 We also write a function that builds the daq systems that we use in our lab. This process involves 1) naming the daq system,
-2) specifying the [ndi.daq.reader](https://vh-lab.github.io/NDI-matlab/reference/+ndi/%2Bdaq/reader.m/) that is used, 3) specifying any [ndi.daq.metadatareader](https://vh-lab.github.io/NDI-matlab/reference/+ndi/%2Bdaq/metadatareader.m/) if necessary, and 
-4) specifying the [ndi.file.navigator](https://vh-lab.github.io/NDI-matlab/reference/+ndi/+file/navigator.m/) to find the files that comprise each epoch.
+2) specifying the [ndi.daq.reader](https://vh-lab.github.io/NDI-matlab/NDI-matlab/reference/+ndi/%2Bdaq/reader.m/) that is used, 3) specifying any [ndi.daq.metadatareader](https://vh-lab.github.io/NDI-matlab/NDI-matlab/reference/+ndi/%2Bdaq/metadatareader.m/) if necessary, and 
+4) specifying the [ndi.file.navigator](https://vh-lab.github.io/NDI-matlab/NDI-matlab/reference/+ndi/+file/navigator.m/) to find the files that comprise each epoch.
 
 If this function here is called with 0 input arguments, then it returns a list of all known daq systems objects for our lab
 (`'vhintan', 'vhspike2', 'vhvis_spike2'`).
 Otherwise, if it is called with the name of a daq system that this function knows how to build, it builds it. It adds the
-appropriate [ndi.daq.reader](https://vh-lab.github.io/NDI-matlab/reference/+ndi/%2Bdaq/reader.m/), [ndi.daq.metadatareader](https://vh-lab.github.io/NDI-matlab/reference/+ndi/%2Bdaq/metadatareader.m/), and [ndi.file.navigator](https://vh-lab.github.io/NDI-matlab/reference/+ndi/+file/navigator.m/).
+appropriate [ndi.daq.reader](https://vh-lab.github.io/NDI-matlab/NDI-matlab/reference/+ndi/%2Bdaq/reader.m/), [ndi.daq.metadatareader](https://vh-lab.github.io/NDI-matlab/NDI-matlab/reference/+ndi/%2Bdaq/metadatareader.m/), and [ndi.file.navigator](https://vh-lab.github.io/NDI-matlab/NDI-matlab/reference/+ndi/+file/navigator.m/).
 
 #### Code block 2.2.4.1: Content of `+ndi/+setup/+daq/+system/vhlab.m`. (Do not type into Matlab command line.)
 
@@ -206,14 +206,14 @@ another file called `vhintan_channelgrouping.txt`. These files are produced by t
 about the probes that were used in that recording and the channel mapping of those probes. We will look at these in more detail later. We use the reader `ndi.daq.reader.mfdaq.intan`, which knows how to read channel data from Intan .rhd files. We tell our
 daq.system object that 'vhintan_channelgrouping.txt' is the file to use to read epochprobemap information (we will instruct it
 how to interpret the data in a later function), and there is no metadata reader `mdr`. We also tell ndi.file.navigator that
-all of these files will appear in subfolders within our main folder by using the [ndi.file.navigator.epochdir](https://vh-lab.github.io/NDI-matlab/reference/+ndi/+file/%2Bnavigator/epochdir.m/) class.
+all of these files will appear in subfolders within our main folder by using the [ndi.file.navigator.epochdir](https://vh-lab.github.io/NDI-matlab/NDI-matlab/reference/+ndi/+file/%2Bnavigator/epochdir.m/) class.
 
 - `vhspike2` - This daq system is very similar to `vhintan`, except that it looks for files that end in .smr and looks for a
 different epochmap metadata file (`vhspike2_channelgrouping.txt`).
 
-- `vhvis_spike2` - This system is more custom. It relies on text files that are generated by our scripts that run on our CED Micro1401 acquisition system: `stimtimes.txt`, `verticalblanking.txt`, `spike2data.smr`, and a file generated by our visual stimulation system called `stims.mat`. We add a metadatareader `ndi.daq.metadatareader.NewStimStims` that knows how to interpret the `stims.mat` file. We will cover this custom [ndi.daq.reader](https://vh-lab.github.io/NDI-matlab/reference/+ndi/%2Bdaq/reader.m/) next.
+- `vhvis_spike2` - This system is more custom. It relies on text files that are generated by our scripts that run on our CED Micro1401 acquisition system: `stimtimes.txt`, `verticalblanking.txt`, `spike2data.smr`, and a file generated by our visual stimulation system called `stims.mat`. We add a metadatareader `ndi.daq.metadatareader.NewStimStims` that knows how to interpret the `stims.mat` file. We will cover this custom [ndi.daq.reader](https://vh-lab.github.io/NDI-matlab/NDI-matlab/reference/+ndi/%2Bdaq/reader.m/) next.
 
-### 2.2.5 Creating a custom [ndi.daq.reader.mfdaq.stimulus](https://vh-lab.github.io/NDI-matlab/reference/%2Bndi/%2Bsetup/%2Bdaq/%2Breader/%2Bmfdaq/%2Bstimulus/vhlabvisspike2.m/) object:
+### 2.2.5 Creating a custom [ndi.daq.reader.mfdaq.stimulus](https://vh-lab.github.io/NDI-matlab/NDI-matlab/reference/%2Bndi/%2Bsetup/%2Bdaq/%2Breader/%2Bmfdaq/%2Bstimulus/vhlabvisspike2.m/) object:
 
 Our visual stimulation system produces a variety of event data, including information about stimulus onset and offset, the
 vertical refresh signal from the monitor, an 8-bit code for each stimulus ID, a video frame trigger (every time we update the
@@ -243,7 +243,7 @@ following fields of information:
 |  ctx |      1    |  n-trode          | ced_daqsystem:ai11 | treeshrew_12345@mylab.org |
 | vis_stim | 1 | stimulator | vis_daqsystem:mk30;text30;md1 | treeshrew_12345@mylab.org |
 
-We need to write a substitute class that is a subclass of [ndi.epoch.epochprobemap](https://vh-lab.github.io/NDI-matlab/reference/%2Bndi/%2Bepoch/epochprobemap.m/) that reads the epoch information and returns all of this same information.
+We need to write a substitute class that is a subclass of [ndi.epoch.epochprobemap](https://vh-lab.github.io/NDI-matlab/NDI-matlab/reference/%2Bndi/%2Bepoch/epochprobemap.m/) that reads the epoch information and returns all of this same information.
 
 In our vhlab session directories, we always have a single subject whose unique identifier is specified in a text file called
 `subject.txt` in the top directory. This file is read, and this text is used as the `subjectstring` for all probes.
@@ -264,7 +264,7 @@ stimulator:
 | ---- | --------- | ---- | ------------ | ------------- |
 | vis_stim | 1 | stimulator | vhvis_spike2:mk1-3;e1-3;md1 | treeshrew_12345@mylab.org |
 
-We will not reproduce the code here but refer the reader to the [link for the source code](https://raw.githubusercontent.com/VH-Lab/NDI-matlab/master/%2Bndi/%2Bsetup/%2Bepoch/epochprobemap_daqsystem_vhlab.m) of the class ndi.setup.epoch.epochprobemap_daqsystem_vhlab that is a subclass of [ndi.epoch.epochprobemap_daqsystem](https://vh-lab.github.io/NDI-matlab/reference/%2Bndi/%2Bepoch/epochprobemap.m/).
+We will not reproduce the code here but refer the reader to the [link for the source code](https://raw.githubusercontent.com/VH-Lab/NDI-matlab/master/%2Bndi/%2Bsetup/%2Bepoch/epochprobemap_daqsystem_vhlab.m) of the class ndi.setup.epoch.epochprobemap_daqsystem_vhlab that is a subclass of [ndi.epoch.epochprobemap_daqsystem](https://vh-lab.github.io/NDI-matlab/NDI-matlab/reference/%2Bndi/%2Bepoch/epochprobemap.m/).
 
 ### 2.2.7 Putting it all together
 

--- a/docs/NDI-matlab/tutorials/analyzing_first_physiology_experiment/3_spikesorting.md
+++ b/docs/NDI-matlab/tutorials/analyzing_first_physiology_experiment/3_spikesorting.md
@@ -8,7 +8,7 @@ Clearly, one could write functions in Matlab that read the data and perform some
 great to share (or borrow) those functions across the open source community, and to develop "apps" that excel at performing
 specific tasks. NDI allows both approaches.
 
-### Tutorial 2.3.1: What is an 'app' in NDI? [ndi.app](https://vh-lab.github.io/NDI-matlab/reference/%2Bndi/app.m/) objects
+### Tutorial 2.3.1: What is an 'app' in NDI? [ndi.app](https://vh-lab.github.io/NDI-matlab/NDI-matlab/reference/%2Bndi/app.m/) objects
 
 An app for our purposes is any application program that can read data from NDI and perform some analysis or
 computation on this data. Some apps exist outside of NDI, and know how to read data from NDI experiments and
@@ -16,18 +16,18 @@ write results back to NDI experimental sessions. One example of such an app is t
 JRClust. 
 
 There is another set of apps that are developed specifically for NDI that are members of a special parent class
-called [ndi.app](https://vh-lab.github.io/NDI-matlab/reference/%2Bndi/app.m/). This parent class performs some services to help app developers maintain a consistant approach to
+called [ndi.app](https://vh-lab.github.io/NDI-matlab/NDI-matlab/reference/%2Bndi/app.m/). This parent class performs some services to help app developers maintain a consistant approach to
 make it easier for users and programmers that want to use the app to easily figure out what it does and how to 
 use it. 
 
 Here, we will examine one of these apps that we made for spike extraction. Just like Windows computers come with
-NotePad and Mac computers come with TextEdit, our [ndi.app.spikeextractor](https://vh-lab.github.io/NDI-matlab/reference/%2Bndi/%2Bapp/spikeextractor.m/) is a plain-but-usable program for
+NotePad and Mac computers come with TextEdit, our [ndi.app.spikeextractor](https://vh-lab.github.io/NDI-matlab/NDI-matlab/reference/%2Bndi/%2Bapp/spikeextractor.m/) is a plain-but-usable program for
 extracting spike waveforms from voltage records. It is suitable for spike extraction situations where the channel count for each electrode is low, such as single electrodes or tetrodes. It is not suitable for dense, multichannel electrodes like NeuroPixels or dense NeuroNexus probes.
 
 We will use the program first as though we knew how to use it by magic, and then we will go through how one could
 figure out how to use the program if one didn't know.
 
-### Tutorial 2.3.2: Extracting spikes using [ndi.app.spikeextractor](https://vh-lab.github.io/NDI-matlab/reference/%2Bndi/%2Bapp/spikeextractor.m/)
+### Tutorial 2.3.2: Extracting spikes using [ndi.app.spikeextractor](https://vh-lab.github.io/NDI-matlab/NDI-matlab/reference/%2Bndi/%2Bapp/spikeextractor.m/)
 
 #### Code block 2.3.2.1. Type this into Matlab.
 
@@ -104,7 +104,7 @@ samples = round(vlt.signal.value2sample(spiketimes, 1/(t(2)-t(1)), 0));
 plot(t(samples),d(samples),'ko'); % mark each spike peak location with a circle 
 ```
 
-### 2.3.3 Spike sorting using [ndi.app.spikesorter](https://vh-lab.github.io/NDI-matlab/reference/%2Bndi/%2Bapp/spikesorter.m/)
+### 2.3.3 Spike sorting using [ndi.app.spikesorter](https://vh-lab.github.io/NDI-matlab/NDI-matlab/reference/%2Bndi/%2Bapp/spikesorter.m/)
 
 Now we will feed our results to our plain spikesorting application, which relies on either Kmeans clustering the KlustaKwik clustering tool (Harris KD, *J. Neurophys.*, 2000).
 
@@ -144,15 +144,15 @@ plot(T,d(samples2), 'gs');
 
 You can observe that most of the spiketimes that were detected on the first probe are part of neuron 1, but there are some lower amplitude peaks that are not.
 
-### 2.3.4 How can we learn about the functionality of [ndi.app](https://vh-lab.github.io/NDI-matlab/reference/%2Bndi/app.m) objects?
+### 2.3.4 How can we learn about the functionality of [ndi.app](https://vh-lab.github.io/NDI-matlab/NDI-matlab/reference/%2Bndi/app.m) objects?
 
-In section 2.2, we used [ndi.app.spikeextractor](https://vh-lab.github.io/NDI-matlab/reference/%2Bndi/%2Bapp/spikeextractor.m/) as though we were born knowning what to do. How could we learn how to use a new app if there isn't a tutorial available?
+In section 2.2, we used [ndi.app.spikeextractor](https://vh-lab.github.io/NDI-matlab/NDI-matlab/reference/%2Bndi/%2Bapp/spikeextractor.m/) as though we were born knowning what to do. How could we learn how to use a new app if there isn't a tutorial available?
 
 There are three great ways to learn about what apps do and how to use them. 
 
 1. Read the main documentation for the app by typing `help *appclass*` or `doc *appclass*` into the Matlab command line. For example, try `help ndi.app.spikeextractor`.
 
-2. Many apps follow what we call the ``appdoc`` convention for creating the documents that they create and loading the documents and data that they have generated. This is a convention that have developed relatively recently, and we are in the process of converting all of our included ndi.app objects to use this form. If an app follows [ndi.app.appdoc](https://vh-lab.github.io/NDI-matlab/reference/%2Bndi/%2Bapp/appdoc.m/) (which means it is a member of the [ndi.app.appdoc](https://vh-lab.github.io/NDI-matlab/reference/%2Bndi/%2Bapp/appdoc.m/) class), then they will have a set of methods called:
+2. Many apps follow what we call the ``appdoc`` convention for creating the documents that they create and loading the documents and data that they have generated. This is a convention that have developed relatively recently, and we are in the process of converting all of our included ndi.app objects to use this form. If an app follows [ndi.app.appdoc](https://vh-lab.github.io/NDI-matlab/NDI-matlab/reference/%2Bndi/%2Bapp/appdoc.m/) (which means it is a member of the [ndi.app.appdoc](https://vh-lab.github.io/NDI-matlab/NDI-matlab/reference/%2Bndi/%2Bapp/appdoc.m/) class), then they will have a set of methods called:
 
 | Method | Description |
 | ------ | ------      |
@@ -162,7 +162,7 @@ There are three great ways to learn about what apps do and how to use them.
 | *find_appdoc* | Find the NDI document for a given type, using the app |
 | *loaddata_appdoc* | Load binary data associated with an NDI document, using the app |
 
-Let's look at the document types that are written and needed by [ndi.app.spikeextractor](https://vh-lab.github.io/NDI-matlab/reference/%2Bndi/%2Bapp/spikeextractor.m/): 
+Let's look at the document types that are written and needed by [ndi.app.spikeextractor](https://vh-lab.github.io/NDI-matlab/NDI-matlab/reference/%2Bndi/%2Bapp/spikeextractor.m/): 
 
 #### Code block 2.3.4.1. Type this into Matlab
 
@@ -170,7 +170,7 @@ Let's look at the document types that are written and needed by [ndi.app.spikeex
 help ndi.app.spikeextractor/appdoc_description
 ```
 
-You see a long bit of text that describes all of the document types that are generated and calculated by [ndi.app.spikeextractor](https://vh-lab.github.io/NDI-matlab/reference/%2Bndi/%2Bapp/spikeextractor.m/).
+You see a long bit of text that describes all of the document types that are generated and calculated by [ndi.app.spikeextractor](https://vh-lab.github.io/NDI-matlab/NDI-matlab/reference/%2Bndi/%2Bapp/spikeextractor.m/).
 
 Here's a table of the document types and their "about" info for ndi.app.spikeextractor:
 

--- a/docs/NDI-matlab/tutorials/analyzing_first_physiology_experiment/4_analyzing_tuning_curves.md
+++ b/docs/NDI-matlab/tutorials/analyzing_first_physiology_experiment/4_analyzing_tuning_curves.md
@@ -3,7 +3,7 @@
 ## 2.4 Analyzing stimulus responses
 
 In the last tutorial, we saw how to use applications to identify spikes from electrophysiology recordings. Now we will employ another plain app 
-for calculating responses to stimulation. Note that this tutorial requires that you have completed [Tutorial 2.3](https://vh-lab.github.io/NDI-matlab/tutorials/analyzing_first_physiology_experiment/3_spikesorting/) (the analysis here depends on the spike sorted results of Tutorial 2.3).
+for calculating responses to stimulation. Note that this tutorial requires that you have completed [Tutorial 2.3](https://vh-lab.github.io/NDI-matlab/NDI-matlab/tutorials/analyzing_first_physiology_experiment/3_spikesorting/) (the analysis here depends on the spike sorted results of Tutorial 2.3).
 
 ### 2.4.1 Sinusoidal gratings to assess direction and orientation preferences and spatial frequency preferences
 
@@ -31,7 +31,7 @@ stimprobe = stimprobe{1}; % grab the first one, should be our stimulus monitor
 ### 2.4.2 Gathering stimulus information
 
 The first step in analyzing stimuli is to gather information about the stimulus presentations that were performed in the experiment. We use a 
-small dedicated app for this purpose called [ndi.app.stimulus.decoder](https://vh-lab.github.io/NDI-matlab/reference/%2Bndi/%2Bapp/%2Bstimulus/decoder.m/).
+small dedicated app for this purpose called [ndi.app.stimulus.decoder](https://vh-lab.github.io/NDI-matlab/NDI-matlab/reference/%2Bndi/%2Bapp/%2Bstimulus/decoder.m/).
 
 #### Code Block 2.4.2.1. Type this into Matlab.
 
@@ -82,7 +82,7 @@ rapp = ndi.app.stimulus.tuning_response(S);
 cs_doc = rapp.label_control_stimuli(stimprobe,redo);
 ```
 
-Let's examine what it did. We see that the [ndi.app.stimuli.tuning_response](https://vh-lab.github.io/NDI-matlab/reference/%2Bndi/%2Bapp/%2Bstimulus/tuning_response.m/) app each of the 85 stimuli with the "blank" stimulus that was presented closest in time:
+Let's examine what it did. We see that the [ndi.app.stimuli.tuning_response](https://vh-lab.github.io/NDI-matlab/NDI-matlab/reference/%2Bndi/%2Bapp/%2Bstimulus/tuning_response.m/) app each of the 85 stimuli with the "blank" stimulus that was presented closest in time:
 
 #### Code Block 2.4.3.2. Type this into Matlab.
 
@@ -99,7 +99,7 @@ help ndi.app.stimulus.tuning_response.label_control_stimuli
 ### 2.4.4 Calculating stimulus responses
 
 Once the control stimuli have been labeled (if desired; it is optional), then one can proceed to calcuate the stimulus responses. To do this, we 
-can employ the [ndi.app.stimuli.tuning_response]((https://vh-lab.github.io/NDI-matlab/reference/%2Bndi/%2Bapp/%2Bstimulus/tuning_response.m/) app. This program will calculate the mean response to each stimulus. Because gratings are a periodic stimulus, this function will also calculate the response at the fundamental stimulus temporal frequency (F1 component) and at twice this temporal frequency (F2 component).
+can employ the [ndi.app.stimuli.tuning_response]((https://vh-lab.github.io/NDI-matlab/NDI-matlab/reference/%2Bndi/%2Bapp/%2Bstimulus/tuning_response.m/) app. This program will calculate the mean response to each stimulus. Because gratings are a periodic stimulus, this function will also calculate the response at the fundamental stimulus temporal frequency (F1 component) and at twice this temporal frequency (F2 component).
 
 #### Code block 2.4.4.1. Type this into Matlab.
 
@@ -139,7 +139,7 @@ rdocs{1}{1}{1}.document_properties.stimulus_response_scalar.responses.control_re
 
 ### 2.4.5 Computing an orientation/direction tuning curve and calculating orientation/direction index values
 
-Now that we have all of the responses to the individual stimuli, we can create a tuning curve, which examines how the response of the neuron depends on a particular stimulus parameter. In this case, the stimulus is 'angle', which corresponds to the direction of the sinusoidal grating stimulus. We have built a specific application [ndi.app.oridirtuning](https://vh-lab.github.io/NDI-matlab/reference/%2Bndi/%2Bapp/oridirtuning.m/) to process tuning curves in response to oriented stimuli, or stimuli moving in particular directions. 
+Now that we have all of the responses to the individual stimuli, we can create a tuning curve, which examines how the response of the neuron depends on a particular stimulus parameter. In this case, the stimulus is 'angle', which corresponds to the direction of the sinusoidal grating stimulus. We have built a specific application [ndi.app.oridirtuning](https://vh-lab.github.io/NDI-matlab/NDI-matlab/reference/%2Bndi/%2Bapp/oridirtuning.m/) to process tuning curves in response to oriented stimuli, or stimuli moving in particular directions. 
 
 After generating the tuning curve, we can calculate many, many index values that characterize the tuning of each cell. The function that calculates the orientation and direction index values pulls up a plot. If you look at the plot that examines the mean response for `ctx_1`, you can see that the cell responds strongly to gratings drifting at 120 degrees and 300 degrees (0 degrees is up; 90 degrees is to the right).
 

--- a/docs/NDI-matlab/tutorials/analyzing_first_physiology_experiment/5_searching_ndi_databases.md
+++ b/docs/NDI-matlab/tutorials/analyzing_first_physiology_experiment/5_searching_ndi_databases.md
@@ -2,12 +2,12 @@
 
 ## 2.5 Understanding and searching the NDI database
 
-### 2.5.1 The [ndi.database](https://vh-lab.github.io/NDI-matlab/reference/%2Bndi/database.m/) and [ndi.document](https://vh-lab.github.io/NDI-matlab/reference/%2Bndi/document.m/) objects
+### 2.5.1 The [ndi.database](https://vh-lab.github.io/NDI-matlab/NDI-matlab/reference/%2Bndi/database.m/) and [ndi.document](https://vh-lab.github.io/NDI-matlab/NDI-matlab/reference/%2Bndi/document.m/) objects
 
-Each [ndi.session](https://vh-lab.github.io/NDI-matlab/reference/%2Bndi/session.m/) object has an [ndi.database](https://vh-lab.github.io/NDI-matlab/reference/%2Bndi/database.m/) object as one of its properties. This database holds the [ndi.document](https://vh-lab.github.io/NDI-matlab/reference/%2Bndi/document.m/) objects 
+Each [ndi.session](https://vh-lab.github.io/NDI-matlab/NDI-matlab/reference/%2Bndi/session.m/) object has an [ndi.database](https://vh-lab.github.io/NDI-matlab/NDI-matlab/reference/%2Bndi/database.m/) object as one of its properties. This database holds the [ndi.document](https://vh-lab.github.io/NDI-matlab/NDI-matlab/reference/%2Bndi/document.m/) objects 
 that contain the metadata and data results of calculations that apps and programs have performed on the original data.
 
-First, let's open the [ndi.session](https://vh-lab.github.io/NDI-matlab/reference/%2Bndi/session.m/) that we've been working with.
+First, let's open the [ndi.session](https://vh-lab.github.io/NDI-matlab/NDI-matlab/reference/%2Bndi/session.m/) that we've been working with.
 
 #### Code block 2.5.1.1. Type this into Matlab.
 
@@ -17,7 +17,7 @@ ref = 'ts_exper2';
 S = ndi.session.dir(ref,dirname);
 ```
 
-We find documents by searching for them with the [ndi.session](https://vh-lab.github.io/NDI-matlab/reference/%2Bndi/session.m/) method `database_search()`. For example, we can examine all documents that contain stimulus presentation data:
+We find documents by searching for them with the [ndi.session](https://vh-lab.github.io/NDI-matlab/NDI-matlab/reference/%2Bndi/session.m/) method `database_search()`. For example, we can examine all documents that contain stimulus presentation data:
 
 #### Code block 2.5.1.2. Type this into Matlab.
 
@@ -47,13 +47,13 @@ stim_pres_doc{1}.document_properties
   %      stimulus_presentation: [1x1 struct]
 ```
 
-We have used an [ndi.query](https://vh-lab.github.io/NDI-matlab/reference/%2Bndi/query.m/) object to conduct our search, and we will describe those objects a little later.
+We have used an [ndi.query](https://vh-lab.github.io/NDI-matlab/NDI-matlab/reference/%2Bndi/query.m/) object to conduct our search, and we will describe those objects a little later.
 
-Here we see that [ndi.document](https://vh-lab.github.io/NDI-matlab/reference/%2Bndi/document.m/) objects have a property called `document_properties` that contains all of the text information that is stored in the document. We will look through all of these properties here, and we also direct you to the documentation page for the ndi.document class [stimulus_presentation](https://vh-lab.github.io/NDI-matlab/documents/stimulus/stimulus_presentation/).
+Here we see that [ndi.document](https://vh-lab.github.io/NDI-matlab/NDI-matlab/reference/%2Bndi/document.m/) objects have a property called `document_properties` that contains all of the text information that is stored in the document. We will look through all of these properties here, and we also direct you to the documentation page for the ndi.document class [stimulus_presentation](https://vh-lab.github.io/NDI-matlab/NDI-matlab/documents/stimulus/stimulus_presentation/).
 
-## 2.5.2 All [ndi.document](https://vh-lab.github.io/NDI-matlab/reference/%2Bndi/document.m/) objects have the fields `document_class` and `base`.
+## 2.5.2 All [ndi.document](https://vh-lab.github.io/NDI-matlab/NDI-matlab/reference/%2Bndi/document.m/) objects have the fields `document_class` and `base`.
 
-The `document_class` fields contain critical information about the class, such as the file that contains its definition and its class name. In addition, document types can be composed of multiple document types. The [stimulus presentation](https://vh-lab.github.io/NDI-matlab/documents/stimulus/stimulus_presentation/) class has two superclasses: [ndi.document](https://vh-lab.github.io/NDI-matlab/documents/base/) and [ndi.document_epochid](https://vh-lab.github.io/NDI-matlab/documents/epochid/). This means that a [stimulus_presentation](https://vh-lab.github.io/NDI-matlab/documents/stimulus/stimulus_presentation/) document has its own fields, plus all of the fields from [ndi.document](https://vh-lab.github.io/NDI-matlab/documents/base/) documents and and [ndi.document_epochid](https://vh-lab.github.io/NDI-matlab/documents/epochid/) documents. 
+The `document_class` fields contain critical information about the class, such as the file that contains its definition and its class name. In addition, document types can be composed of multiple document types. The [stimulus presentation](https://vh-lab.github.io/NDI-matlab/NDI-matlab/documents/stimulus/stimulus_presentation/) class has two superclasses: [ndi.document](https://vh-lab.github.io/NDI-matlab/NDI-matlab/documents/base/) and [ndi.document_epochid](https://vh-lab.github.io/NDI-matlab/NDI-matlab/documents/epochid/). This means that a [stimulus_presentation](https://vh-lab.github.io/NDI-matlab/NDI-matlab/documents/stimulus/stimulus_presentation/) document has its own fields, plus all of the fields from [ndi.document](https://vh-lab.github.io/NDI-matlab/NDI-matlab/documents/base/) documents and and [ndi.document_epochid](https://vh-lab.github.io/NDI-matlab/NDI-matlab/documents/epochid/) documents. 
 
 Let's look at the data that specifies the superclasses:
 
@@ -87,7 +87,7 @@ stim_pres_doc{1}.document_properties.document_class.superclasses(3)
 %    definition: '$NDIDOCUMENTPATH/base.json'
 ```
 
-All documents have [base](https://vh-lab.github.io/NDI-matlab/documents/base/) as a superclass. Note that [ndi.document](https://vh-lab.github.io/NDI-matlab/reference/%2Bndi/document.m/) is the name of the software object in Matlab (and Python), whereas [base](https://vh-lab.github.io/NDI-matlab/documents/base/) is the name of the database object type that has the following fields:
+All documents have [base](https://vh-lab.github.io/NDI-matlab/NDI-matlab/documents/base/) as a superclass. Note that [ndi.document](https://vh-lab.github.io/NDI-matlab/NDI-matlab/reference/%2Bndi/document.m/) is the name of the software object in Matlab (and Python), whereas [base](https://vh-lab.github.io/NDI-matlab/NDI-matlab/documents/base/) is the name of the database object type that has the following fields:
 
 | field | default_value | data type | description |
 | --- | --- | --- | --- |
@@ -98,12 +98,12 @@ All documents have [base](https://vh-lab.github.io/NDI-matlab/documents/base/) a
 | **datestamp** | (current time) | ISO-8601 date string, time zone must be UTC leap seconds | Time of document creation |
 | **database_version** | - | character array (ASCII) | Version of this document in the database |
 
-The most useful item in each [ndi.document](https://vh-lab.github.io/NDI-matlab/reference/%2Bndi/document.m/) is its unique identifier `id`. This is a globally unique identifier, which means that no other [ndi.document](https://vh-lab.github.io/NDI-matlab/reference/%2Bndi/document.m/) or corresponding [base](https://vh-lab.github.io/NDI-matlab/documents/base/) anywhere in the universe has the same identifier. It is constructed of two hexidecimal strings: the first is based on the time of creation in Universal Controlled Time (UTC), and the second is created by a random number generator. This constructions means that `ndi.document` ids are not only unique, but also that sorting them alphabetically will give you the creation order of the documents. This can come in handy from time to time.
+The most useful item in each [ndi.document](https://vh-lab.github.io/NDI-matlab/NDI-matlab/reference/%2Bndi/document.m/) is its unique identifier `id`. This is a globally unique identifier, which means that no other [ndi.document](https://vh-lab.github.io/NDI-matlab/NDI-matlab/reference/%2Bndi/document.m/) or corresponding [base](https://vh-lab.github.io/NDI-matlab/NDI-matlab/documents/base/) anywhere in the universe has the same identifier. It is constructed of two hexidecimal strings: the first is based on the time of creation in Universal Controlled Time (UTC), and the second is created by a random number generator. This constructions means that `ndi.document` ids are not only unique, but also that sorting them alphabetically will give you the creation order of the documents. This can come in handy from time to time.
 
-## 2.5.3 Searching for [base](https://vh-lab.github.io/NDI-matlab/documents/base/) with [ndi.query](https://vh-lab.github.io/NDI-matlab/reference/%2Bndi/query.m/)
+## 2.5.3 Searching for [base](https://vh-lab.github.io/NDI-matlab/NDI-matlab/documents/base/) with [ndi.query](https://vh-lab.github.io/NDI-matlab/NDI-matlab/reference/%2Bndi/query.m/)
 
 Performing analyses or analyses of analyses in NDI involves searching for previous entries in the database, building upon them, and writing the
-results back to the database. The object [ndi.query](https://vh-lab.github.io/NDI-matlab/reference/%2Bndi/query.m/) allows one to express database searches. Let's learn about [ndi.query](https://vh-lab.github.io/NDI-matlab/reference/%2Bndi/query.m/) with a few examples.
+results back to the database. The object [ndi.query](https://vh-lab.github.io/NDI-matlab/NDI-matlab/reference/%2Bndi/query.m/) allows one to express database searches. Let's learn about [ndi.query](https://vh-lab.github.io/NDI-matlab/NDI-matlab/reference/%2Bndi/query.m/) with a few examples.
 
 #### Code block 2.5.3.1. Type this into Matlab.
 
@@ -230,7 +230,7 @@ mydoc{1}.document_properties.element
 % We see it is our visual stimulation system
 ```
 
-Some documents have a lot of depends_on items. Let's examine our ctx_1 neuron that we created in [Tutorial 2.3](https://vh-lab.github.io/NDI-matlab/tutorials/analyzing_first_physiology_experiment/3_spikesorting/).
+Some documents have a lot of depends_on items. Let's examine our ctx_1 neuron that we created in [Tutorial 2.3](https://vh-lab.github.io/NDI-matlab/NDI-matlab/tutorials/analyzing_first_physiology_experiment/3_spikesorting/).
 
 #### Code block 2.5.4.2. Type this into Matlab.
 ```matlab
@@ -249,7 +249,7 @@ end;
 %   Depends on spike_clusters_id: 412687f62d1057b8_40c28348e09e5e9b
 ```
 
-### 2.5.5 Structure of an [ndi.database](https://vh-lab.github.io/NDI-matlab/reference/%2Bndi/database.m/)
+### 2.5.5 Structure of an [ndi.database](https://vh-lab.github.io/NDI-matlab/NDI-matlab/reference/%2Bndi/database.m/)
 
 NDI databases (and any analysis project) has a beautiful underlying structure that one can visualize, to get a sense of how the calculations and inferred objects (like neurons that spike) are derived from one another.
 

--- a/docs/NDI-matlab/tutorials/analyzing_first_physiology_experiment_detailed/1_example_dataset.md
+++ b/docs/NDI-matlab/tutorials/analyzing_first_physiology_experiment_detailed/1_example_dataset.md
@@ -2,7 +2,7 @@
 ## Getting started with NDI
 
 
-This tutorial is an alternative to [Tutorial 2.1](https://vh-lab.github.io/NDI-matlab/tutorials/analyzing_first_physiology_experiment/1_example_dataset/) that is designed for users who are less familiar with programming. It will provide a brief overview of Matlab and object-oriented programming, more in-depth information about the methods and syntax used, and a guide on how to navigate the website and its documentation. 
+This tutorial is an alternative to [Tutorial 2.1](https://vh-lab.github.io/NDI-matlab/NDI-matlab/tutorials/analyzing_first_physiology_experiment/1_example_dataset/) that is designed for users who are less familiar with programming. It will provide a brief overview of Matlab and object-oriented programming, more in-depth information about the methods and syntax used, and a guide on how to navigate the website and its documentation. 
 
 ## Basics of Matlab
 Matlab is a language specifically designed for calculations, data visualization, and pattern recognition. It is less flexible in some areas than traditional programming languages, but it excels when working with matrices and **arrays**, which are data structures that contain multiple elements. It includes many built-in tools and additional libraries for a large variety of tasks.
@@ -12,7 +12,7 @@ Matlab allows for object-oriented programming, a programming paradigm where data
 Classes define the states and behaviors of its objects, and constructors determine the initial values of a given object's attributes, called **variables.** Variables are used within programs to store all kinds of information, including numbers, individual characters, strings of characters, or arrays, which include a larger number of any given type of variable. Unlike many other programming languages, we do not have to specifically state a variable's type when declaring it.
 
 We will start with learning to read an example dataset into NDI. We assume you have already
-[installed NDI](https://vh-lab.github.io/NDI-matlab/installation/) and taken the [introductory tutorial of the NDI model](https://vh-lab.github.io/NDI-matlab/tutorials/ndimodel/1_intro/). These data are available in a
+[installed NDI](https://vh-lab.github.io/NDI-matlab/NDI-matlab/installation/) and taken the [introductory tutorial of the NDI model](https://vh-lab.github.io/NDI-matlab/NDI-matlab/tutorials/ndimodel/1_intro/). These data are available in a
 compressed folder
 [here](https://drive.google.com/file/d/1j7IAeMSrH64-qIDLB5EJYUofJSdinwuU/view?usp=sharing). To learn more about Matlab, take a look at <mathwork website link>.
 Prior to starting the code, put the "ts_exper1" folder into your NDI folder. The NDI folder should be listed under MATLAB\Documents\NDI, which is created during the installation of NDI. The MATLAB folder itself is found in the default Documents folder in the Finder.
@@ -75,7 +75,7 @@ In this block, we again assign a path to a variable. In this case, we use the fu
 The next line introduces the concept of packages and their functions. Packages are folders that are used primarily to organize related classes and functions; they can also contain other subpackages. The syntax of our class tells us how the packages are structured: the main package is named "ndi," our subpackage is named "example," and the next subpackage is called "tutorial."  Functions are files that contain multiple lines of code that receive inputs. As opposed to a script, which is a program that performs exactly the same way every time, functions are more like mathematical equations, having varied outputs or effects depending on their inputs. Our function is called plottreeshrewdata, which naturally plots the tree shrew neural data that our electrode gathered. This particular function requires an input parameter. In this case, this function requires a path to a specific file, which it will plot based on the file's data. Functions are useful when you have a specific piece of code that must be repeated several times and also requires many unique inputs. 
 
 Information about NDI packages and classes can be found in the documentation on the sidebar. The sidebar shows the hierarchy of packages and classes under the document reference and the syntax, descriptions of each parameter, and overall function of every method under the code reference. 
-This particular method is found [here](https://vh-lab.github.io/NDI-matlab/reference/%2Bndi/%2Bexample/%2Btutorial/plottreeshrewdata.m/). Looking at the documentation is one of the best ways to familiarize yourself with the different classes and methods of any program. 
+This particular method is found [here](https://vh-lab.github.io/NDI-matlab/NDI-matlab/reference/%2Bndi/%2Bexample/%2Btutorial/plottreeshrewdata.m/). Looking at the documentation is one of the best ways to familiarize yourself with the different classes and methods of any program. 
 
 This function shows the raw voltage recording and the stimulus timing information. Each stimulus appears as a number and its duration is indicated by the black bar. You can pan with the mouse to scroll through the recording.
 
@@ -85,11 +85,11 @@ This function shows the raw voltage recording and the stimulus timing informatio
 Metadata is "data about data"- in this case, metadata is all information about the probes themselves, including their names, types, and unique identification. In this example, we have already prepared the metadata files that are necessary for NDI to read the data. Let's look at them in turn.
 
 First, we need to tell NDI what **probes** we have in our experiment. A **probe** is anything that measures or stimulates; one end of a probe 
-is connected to a **subject**, and the other end of a probe is connected to a data acquisition device. We first create an object of class [ndi.epoch.epochprobemap](https://vh-lab.github.io/NDI-matlab/reference/%2Bndi/%2Bepoch/epochprobemap.m/). Again, the name of this object tells us that it was created from class epochprobemap, which is a class of the epoch package, which is itself a subpackage of the ndi package. Both classes we have seen are in the epoch package, indicating that they both relate to the function and display of epochs. The organization of packages can help us determine what the packages' contents should generally do; as always, make sure to look at the documentation for more specific information about a particular file.
+is connected to a **subject**, and the other end of a probe is connected to a data acquisition device. We first create an object of class [ndi.epoch.epochprobemap](https://vh-lab.github.io/NDI-matlab/NDI-matlab/reference/%2Bndi/%2Bepoch/epochprobemap.m/). Again, the name of this object tells us that it was created from class epochprobemap, which is a class of the epoch package, which is itself a subpackage of the ndi package. Both classes we have seen are in the epoch package, indicating that they both relate to the function and display of epochs. The organization of packages can help us determine what the packages' contents should generally do; as always, make sure to look at the documentation for more specific information about a particular file.
 
 
 We usually tell NDI how the probe is connected with a little code that instructs NDI how to read this information directly from the laboratory's own file information, but in this example, we will use the
-generic [ndi.epoch.epochprobemap_daqsystem](https://vh-lab.github.io/NDI-matlab/reference/%2Bndi/%2Bepoch/epochprobemap_daqsystem.m/) object, which reads in a simple tab-delimited text file. This line introduces the first instance of a class method. Methods are the operations of a class, taking in inputs called parameters and performing an action, often returning an output. This particular method is a **constructor,** which is a class method that takes in values and instantiates an object of the class with those specific values. 
+generic [ndi.epoch.epochprobemap_daqsystem](https://vh-lab.github.io/NDI-matlab/NDI-matlab/reference/%2Bndi/%2Bepoch/epochprobemap_daqsystem.m/) object, which reads in a simple tab-delimited text file. This line introduces the first instance of a class method. Methods are the operations of a class, taking in inputs called parameters and performing an action, often returning an output. This particular method is a **constructor,** which is a class method that takes in values and instantiates an object of the class with those specific values. 
 
 If we take a closer look at this class, we see the example constructor
 MYNDI_EPOCHPROBEMAP_DAQSYSTEM = ndi.epoch.epochprobemap(NAME, REFERENCE, TYPE, DEVICESTRING, SUBJECTSTRING). This is the general form of a constructor in Matlab: first is the name of the object, which is everything on the left side of the equals sign, then the name of the class that the constructor is part of, which is ndi.epoch.epochprobemap in this case, then each parameter, which is the list of words separated by commas. Note that the name of the object is the name used internally by our program, and is not necessarily the same as the NAME argument that we provide when we make the object. 
@@ -138,9 +138,9 @@ data can be read directly, but here we have made another tab-delimited text file
 type (fullfile(prefix,'ts_exper1','t00001','stims.tsv'))
 ```
 
-### 3.1.4 Gaining access to the data in NDI: [ndi.session](https://vh-lab.github.io/NDI-matlab/reference/%2Bndi/session.m/) and [ndi.daq.system](https://vh-lab.github.io/NDI-matlab/reference/%2Bndi/%2Bdaq/system.m/) objects
+### 3.1.4 Gaining access to the data in NDI: [ndi.session](https://vh-lab.github.io/NDI-matlab/NDI-matlab/reference/%2Bndi/session.m/) and [ndi.daq.system](https://vh-lab.github.io/NDI-matlab/NDI-matlab/reference/%2Bndi/%2Bdaq/system.m/) objects
 
-Now all that remains is to open the data directory (folder) as an [ndi.session](https://vh-lab.github.io/NDI-matlab/reference/%2Bndi/session.m/) object, and make [ndi.daq.system](https://vh-lab.github.io/NDI-matlab/reference/%2Bndi/%2Bdaq/system.m/) objects to read your data. We will use an [ndi.session.dir](https://vh-lab.github.io/NDI-matlab/reference/%2Bndi/%2Bsession/dir.m/) object, which allows us to read information from a directory on disk. 
+Now all that remains is to open the data directory (folder) as an [ndi.session](https://vh-lab.github.io/NDI-matlab/NDI-matlab/reference/%2Bndi/session.m/) object, and make [ndi.daq.system](https://vh-lab.github.io/NDI-matlab/NDI-matlab/reference/%2Bndi/%2Bdaq/system.m/) objects to read your data. We will use an [ndi.session.dir](https://vh-lab.github.io/NDI-matlab/NDI-matlab/reference/%2Bndi/%2Bsession/dir.m/) object, which allows us to read information from a directory on disk. 
 
 We will create a new ndi.system object by calling the constructor with the reference name we wish to give to the session and the pathname to our data:
 
@@ -163,17 +163,17 @@ S.getprobes()
 
 Unless you ran this demo before, you won't see any probes here (it will return an empty cell array). This is the first method we've seen that is not a constructor. Note that we must call this method along with our session object: this is an example of a non-static method, which belongs to a specific object of the class. Much like calling functions, you use a dot between the name of the object and the name of the method. The parentheses after the method are necessary for every method, even if they have no arguments like in this case.
 
-We need to make new [ndi.daq.system](https://vh-lab.github.io/NDI-matlab/reference/%2Bndi/%2Bdaq/system.m/) objects for our data acquisition system and our stimulator. Our devices are
-multifunction data acquisition systems, so we use the [ndi.daq.system.mfdaq](https://vh-lab.github.io/NDI-matlab/reference/%2Bndi/%2Bdaq/%2Bsystem/mfdaq.m/) subtype.
+We need to make new [ndi.daq.system](https://vh-lab.github.io/NDI-matlab/NDI-matlab/reference/%2Bndi/%2Bdaq/system.m/) objects for our data acquisition system and our stimulator. Our devices are
+multifunction data acquisition systems, so we use the [ndi.daq.system.mfdaq](https://vh-lab.github.io/NDI-matlab/NDI-matlab/reference/%2Bndi/%2Bdaq/%2Bsystem/mfdaq.m/) subtype.
 
-An [ndi.daq.system](https://vh-lab.github.io/NDI-matlab/reference/%2Bndi/%2Bdaq/system.m/) object consists of three components: an
-[ndi.file.navigator](https://vh-lab.github.io/NDI-matlab/reference/%2Bndi/%2Bfile/navigator.m/) object whose job it is to find the files or
+An [ndi.daq.system](https://vh-lab.github.io/NDI-matlab/NDI-matlab/reference/%2Bndi/%2Bdaq/system.m/) object consists of three components: an
+[ndi.file.navigator](https://vh-lab.github.io/NDI-matlab/NDI-matlab/reference/%2Bndi/%2Bfile/navigator.m/) object whose job it is to find the files or
 streams associated with
-each epoch of data, an [ndi.daq.reader](https://vh-lab.github.io/NDI-matlab/reference/%2Bndi/%2Bdaq/reader.m/) object whose job it is to read the raw data from the files, and an
-[ndi.daq.metadatareader](https://vh-lab.github.io/NDI-matlab/reference/%2Bndi/%2Bdaq/metadatareader.m/) (optionally) whose
+each epoch of data, an [ndi.daq.reader](https://vh-lab.github.io/NDI-matlab/NDI-matlab/reference/%2Bndi/%2Bdaq/reader.m/) object whose job it is to read the raw data from the files, and an
+[ndi.daq.metadatareader](https://vh-lab.github.io/NDI-matlab/NDI-matlab/reference/%2Bndi/%2Bdaq/metadatareader.m/) (optionally) whose
 job is to read any metadata associated with the epoch (such as stimulus parameter information). 
 
-First, we will build an [ndi.daq.system.mfdaq](https://vh-lab.github.io/NDI-matlab/reference/%2Bndi/%2Bdaq/%2Bsystem/mfdaq.m/) object that we will call `'ced_daqsystem'` to
+First, we will build an [ndi.daq.system.mfdaq](https://vh-lab.github.io/NDI-matlab/NDI-matlab/reference/%2Bndi/%2Bdaq/%2Bsystem/mfdaq.m/) object that we will call `'ced_daqsystem'` to
 read the electrode data from our CED SMR files.
 
 #### Code block 3.1.4.3. Building an ndi.daq.system.mfdaq object. Type this in to Matlab:
@@ -189,7 +189,7 @@ S.daqsystem_add(ced_system);
 
 Note: If you ran the tutorial before, you may have added `ced_system` to your session `S` already. That's fine, you'll get an error if you try to do it again. If you want to remove all your daq systems, you can call `ndi.session.daqsystem_clear()` by typing `S.daqsystem_clear()`, and then you can add them again.
 
-We first create the file navigator object, ced_filenav, utilizing the ndi.file.navigator constructor. As always, we need to specify the parameters of this navigator object. The properties of this class are listed [here](https://vh-lab.github.io/NDI-matlab/reference/%2Bndi/%2Bfile/navigator.m/), and will also be listed here for convenience.
+We first create the file navigator object, ced_filenav, utilizing the ndi.file.navigator constructor. As always, we need to specify the parameters of this navigator object. The properties of this class are listed [here](https://vh-lab.github.io/NDI-matlab/NDI-matlab/reference/%2Bndi/%2Bfile/navigator.m/), and will also be listed here for convenience.
 
 
 
@@ -229,7 +229,7 @@ The method ced_system.filenavigator.getepochfiles(1) assigns all the files in ep
 
 The two lines of code described above are used to take a look at what epochs and epoch files exist in our session. 
 
-Second, we will build an [ndi.daq.system.mfdaq](https://vh-lab.github.io/NDI-matlab/reference/%2Bndi/%2Bdaq/%2Bsystem/mfdaq.m/) object for our visual stimulus system. The setup for this DAQ system will be very similar to the prior example. 
+Second, we will build an [ndi.daq.system.mfdaq](https://vh-lab.github.io/NDI-matlab/NDI-matlab/reference/%2Bndi/%2Bdaq/%2Bsystem/mfdaq.m/) object for our visual stimulus system. The setup for this DAQ system will be very similar to the prior example. 
 
 #### Code block 3.1.4.5. Building another ndi.daq.system.mfdaq object. Type this in to Matlab:
 
@@ -262,7 +262,7 @@ We create an object nsf of class ndi.time.synchrule.filematch, which dictates th
 
 This object is added to the session through the syncgraph_addrule() method so that NDI knows which DAQ systems to synchronize in our experiment. We know that the stimulator (vis_system) and the data acquisition system (ced_system) are in sync because they both share spike2data.smr and probemap.txt. 
 
-### 3.1.5 Opening the data in NDI: accessing probes via from [ndi.daq.system.mfdaq](https://vh-lab.github.io/NDI-matlab/reference/%2Bndi/%2Bdaq/%2Bsystem/mfdaq.m/)
+### 3.1.5 Opening the data in NDI: accessing probes via from [ndi.daq.system.mfdaq](https://vh-lab.github.io/NDI-matlab/NDI-matlab/reference/%2Bndi/%2Bdaq/%2Bsystem/mfdaq.m/)
 
 Now we can use NDI to see the probes that these daq systems can find and to access the data from those probes. Let's look at the electrode probe data first.
 
@@ -296,7 +296,7 @@ Finally, the p{i} shows the contents of element i of array p. Since i is our loo
 Before we take a look at the epoch data for each probe, we need to specify the probe in question. To get access to the probe that we want, we create an array p_ctx1_list utilizing the getprobes method while specifying the name and reference number. In the parenthesis of the method we write the name of the field followed by its value, so the method returns all probes with name 'ctx' and reference number 1. When we run this line of code we see that p_ctx1_list is a 1x1 cell array, so only one probe matches these criteria.
 
 You can see that probe 1 has a *name* of `ctx`, a *reference* of `1`, and it is of *type* `n-trode`, or an n-channel electrode. It has a software
-object type of [ndi.probe.timeseries.mfdaq](https://vh-lab.github.io/NDI-matlab/reference/%2Bndi/%2Bprobe/%2Btimeseries/mfdaq.m/), which simply means it is associated with multifunction DAQ systems and returns timeseries observations.
+object type of [ndi.probe.timeseries.mfdaq](https://vh-lab.github.io/NDI-matlab/NDI-matlab/reference/%2Bndi/%2Bprobe/%2Btimeseries/mfdaq.m/), which simply means it is associated with multifunction DAQ systems and returns timeseries observations.
 
 We then assign the first element(probe 1) in array p to the variable p_ctx1.
 ```	 p_ctx1 = p_ctx1_list{1}.	```
@@ -354,7 +354,7 @@ This code is nearly identical to what we used in code block 3.1.5.1.
 
 Now let's read the data from our stimulator. To do this, we are going to ask NDI to read the stimulus timing information
 in the time units of our electrode probe `p_ctx`. You'll notice that when we read data from `p_ctx1`, `readtimeseries` returned
-an [ndi.time.timereference](https://vh-lab.github.io/NDI-matlab/reference/%2Bndi/%2Btime/timereference.m/) object `timeref_p_ctx1`.
+an [ndi.time.timereference](https://vh-lab.github.io/NDI-matlab/NDI-matlab/reference/%2Bndi/%2Btime/timereference.m/) object `timeref_p_ctx1`.
 Let's examine this quickly:
 
 #### Code block 3.1.5.4. Taking a look at the ndi.time.timereference object. Type this in to Matlab:
@@ -365,7 +365,7 @@ timeref_p_ctx1
 
 You'll see a structure with the following fields:
 
-| `timeref_p_ctx1`  | [timereference](https://vh-lab.github.io/NDI-matlab/reference/%2Bndi/%2Btime/timereference.m/) with properties |
+| `timeref_p_ctx1`  | [timereference](https://vh-lab.github.io/NDI-matlab/NDI-matlab/reference/%2Bndi/%2Btime/timereference.m/) with properties |
 | ---- | ---- |
 | referent |  `[1x1 ndi.probe.timeseries.mfdaq]` | 
 | clocktype |  `[1x1 ndi.time.clocktype]` |
@@ -406,7 +406,7 @@ data.parameters{1}
 ```
 
 Here we examined several fields of the variables `data` and `t` returned from `readtimeseries` from our
-[ndi.probe.timeseries.stimulator](https://vh-lab.github.io/NDI-matlab/reference/%2Bndi/%2Bprobe/%2Btimeseries/stimulator.m/).
+[ndi.probe.timeseries.stimulator](https://vh-lab.github.io/NDI-matlab/NDI-matlab/reference/%2Bndi/%2Bprobe/%2Btimeseries/stimulator.m/).
 
 You can see that `t` is a structure with 2 fields, `stimon` and `stimoff`. Our system kept track of when each stimulus began, but in these recordings, we did not have our data acquisition system
 keep track of when our stimulus turned off. (For later analysis, we will need to read this from the stimulus parameters.)

--- a/docs/NDI-matlab/tutorials/making_documents/1_making_documents.md
+++ b/docs/NDI-matlab/tutorials/making_documents/1_making_documents.md
@@ -9,7 +9,7 @@ Creating an NDI document class involves creating two .JSON files. The first is a
 The first step in designing a database document is to decide where it goes. If you are designing a document for NDI proper, then it should go in a subdirectory of
 `NDI-matlab/ndi_common/database_documents`.
 
-Let's look at the design of the database document definition for [ndi.calc.example.simple](https://vh-lab.github.io/NDI-matlab/reference/%2Bndi/%2Bcalc/%2Bexample/simple.m/), which we placed in `ndi_common/database_documents/apps/calculations/simple_calc.json`:
+Let's look at the design of the database document definition for [ndi.calc.example.simple](https://vh-lab.github.io/NDI-matlab/NDI-matlab/reference/%2Bndi/%2Bcalc/%2Bexample/simple.m/), which we placed in `ndi_common/database_documents/apps/calculations/simple_calc.json`:
 
 #### Code block 7.2.2.1: Database documentation definition for `simple_calc` (Do not type into Matlab command line)
 

--- a/docs/NDI-matlab/tutorials/writing_own_app/2_ndi_calculations.md
+++ b/docs/NDI-matlab/tutorials/writing_own_app/2_ndi_calculations.md
@@ -3,16 +3,16 @@
 ## 7.2: Writing a simple calculation
 
 Usually, end user scientists do not want to develop an app, but instead want to develop a consistent and tested
-method for performing a calculation. We have developed an NDI mini-app class called [ndi.calculation](https://vh-lab.github.io/NDI-matlab/reference/%2Bndi/calculation.m/) for that purpose.
+method for performing a calculation. We have developed an NDI mini-app class called [ndi.calculation](https://vh-lab.github.io/NDI-matlab/NDI-matlab/reference/%2Bndi/calculation.m/) for that purpose.
 
-[ndi.calculation](https://vh-lab.github.io/NDI-matlab/reference/%2Bndi/calculation.m/) objects require very little in the way of construction:
+[ndi.calculation](https://vh-lab.github.io/NDI-matlab/NDI-matlab/reference/%2Bndi/calculation.m/) objects require very little in the way of construction:
 
 1. A single document type that they produce
 2. A function that creates the document type from input parameters
 3. A function that searches for all possible inputs to the function
 4. A short documentation for the document type
 
-Once we have these ingredients, we have an [ndi.calculation](https://vh-lab.github.io/NDI-matlab/reference/%2Bndi/calculation.m/) that can be run as simply as
+Once we have these ingredients, we have an [ndi.calculation](https://vh-lab.github.io/NDI-matlab/NDI-matlab/reference/%2Bndi/calculation.m/) that can be run as simply as
 
 #### Code block 7.2.0.1 (Don't type into the Matlab command line until the end, at the bottom.)
 
@@ -21,11 +21,11 @@ c = ndi.calc.example.simple(S); % where S is an ndi.session
 c.run('NoAction'); % will run but will not replace existing calculations with the same parameters
 ```
 
-We will cover the develop of a very simple calculation: [ndi.calc.example.simple](https://vh-lab.github.io/NDI-matlab/reference/%2Bndi/%2Bcalc/%2Bexample/simple.m/)
+We will cover the develop of a very simple calculation: [ndi.calc.example.simple](https://vh-lab.github.io/NDI-matlab/NDI-matlab/reference/%2Bndi/%2Bcalc/%2Bexample/simple.m/)
 
 ### 7.2.1 ndi.calc.example.simple
 
-Our simple example will be very simple and silly, but illustrates the process of creating an [ndi.calculation](https://vh-lab.github.io/NDI-matlab/reference/%2Bndi/calculation.m/).
+Our simple example will be very simple and silly, but illustrates the process of creating an [ndi.calculation](https://vh-lab.github.io/NDI-matlab/NDI-matlab/reference/%2Bndi/calculation.m/).
 
 We will create a calculation that creates a document for each 'ndi.probe' object that simply has a field called
 'answer' that is equal to 5. It is not useful for anything other than demonstrating the steps necessary to create a calculation, but you
@@ -33,7 +33,7 @@ can use it to design calculations that perform useful analysis and save the resu
 
 ### 7.2.2 Designing the database document
 
-Let's look at the design of the database document definition for [ndi.calc.example.simple](https://vh-lab.github.io/NDI-matlab/reference/%2Bndi/%2Bcalc/%2Bexample/simple.m/), which we placed in `ndi_common/database_documents/apps/calculations/simple_calc.json`:
+Let's look at the design of the database document definition for [ndi.calc.example.simple](https://vh-lab.github.io/NDI-matlab/NDI-matlab/reference/%2Bndi/%2Bcalc/%2Bexample/simple.m/), which we placed in `ndi_common/database_documents/apps/calculations/simple_calc.json`:
 
 #### Code block 7.2.2.1: Database documentation definition for `simple_calc` (Do not type into Matlab command line)
 
@@ -82,13 +82,13 @@ case is a simple field "answer".
 We are now ready to write the calculation code. This is the code that we will call to make our calculation.  The code has four functions. 
 
 The first function that is needed is the *creator*. This function has the same name as the class and does any building that is necessary
-to make the calculation function. Because [ndi.calculation](https://vh-lab.github.io/NDI-matlab/reference/%2Bndi/calculation.m/) is a subclass of [ndi.app](https://vh-lab.github.io/NDI-matlab/reference/%2Bndi/app.m/) and [ndi.appdoc](https://vh-lab.github.io/NDI-matlab/reference/%2Bndi/%2Bapp/appdoc.m/), most of our initialization is handled for us.
-Our code object `simple` is a subclass of [ndi.calculation](https://vh-lab.github.io/NDI-matlab/reference/%2Bndi/calculation.m/), which has a handy routine that can be used to tell the object what document it should
+to make the calculation function. Because [ndi.calculation](https://vh-lab.github.io/NDI-matlab/NDI-matlab/reference/%2Bndi/calculation.m/) is a subclass of [ndi.app](https://vh-lab.github.io/NDI-matlab/NDI-matlab/reference/%2Bndi/app.m/) and [ndi.appdoc](https://vh-lab.github.io/NDI-matlab/NDI-matlab/reference/%2Bndi/%2Bapp/appdoc.m/), most of our initialization is handled for us.
+Our code object `simple` is a subclass of [ndi.calculation](https://vh-lab.github.io/NDI-matlab/NDI-matlab/reference/%2Bndi/calculation.m/), which has a handy routine that can be used to tell the object what document it should
 make. 
 
 Here is a snapshot of the creator function. Note that this code snippet can't stand on its own; we will give the full object code at the bottom.
 
-#### Code block 7.2.3.1: Creator for [ndi.calc.example.simple](https://vh-lab.github.io/NDI-matlab/reference/%2Bndi/%2Bcalc/%2Bexample/simple.m/) (do not type into Matlab command line):
+#### Code block 7.2.3.1: Creator for [ndi.calc.example.simple](https://vh-lab.github.io/NDI-matlab/NDI-matlab/reference/%2Bndi/%2Bcalc/%2Bexample/simple.m/) (do not type into Matlab command line):
 
 ```matlab
 		function simple_obj = simple(session)
@@ -108,7 +108,7 @@ The second function is the `calculate` function that actually performs the calcu
 to have the same fields as the structure that holds the central data of the document; in this case, it needs to be a structure with the fields
 of `simple` in the document above (`input_parameters`, `depends_on`,`simple`).
 
-#### Code block 7.2.3.2: `calculate` function for [ndi.calc.example.simple](https://vh-lab.github.io/NDI-matlab/reference/%2Bndi/%2Bcalc/%2Bexample/simple.m/) (do not type into Matlab command line):
+#### Code block 7.2.3.2: `calculate` function for [ndi.calc.example.simple](https://vh-lab.github.io/NDI-matlab/NDI-matlab/reference/%2Bndi/%2Bcalc/%2Bexample/simple.m/) (do not type into Matlab command line):
 
 ```matlab
 	function doc = calculate(ndi_calculation_obj, parameters)
@@ -140,7 +140,7 @@ correctly so that the function can perform its calculation. The user can do this
 object search for all of the possible inputs on which it can perform the calculation. This allows the calculation to be called simply by the `run`
 function. 
 
-#### Code block 7.2.3.3: `default_search_for_input_parameters` function for [ndi.calc.example.simple](https://vh-lab.github.io/NDI-matlab/reference/%2Bndi/%2Bcalc/%2Bexample/simple.m/) (do not type into Matlab command line):
+#### Code block 7.2.3.3: `default_search_for_input_parameters` function for [ndi.calc.example.simple](https://vh-lab.github.io/NDI-matlab/NDI-matlab/reference/%2Bndi/%2Bcalc/%2Bexample/simple.m/) (do not type into Matlab command line):
 
 ```matlab
 		function parameters = default_search_for_input_parameters(ndi_calculation_obj)
@@ -160,7 +160,7 @@ function.
 The last function that we need is a documentation function that simply returns its own help as a text string. This allows other programs to
 see the documentation for the calculation, and gives programmers/users a consistent place in the help to look for a description of what the calculation does.
 
-#### Code block 7.2.3.4 `doc_about` for [ndi.calc.example.simple](https://vh-lab.github.io/NDI-matlab/reference/%2Bndi/%2Bcalc/%2Bexample/simple.m/) (do not type into Matlab command line):
+#### Code block 7.2.3.4 `doc_about` for [ndi.calc.example.simple](https://vh-lab.github.io/NDI-matlab/NDI-matlab/reference/%2Bndi/%2Bcalc/%2Bexample/simple.m/) (do not type into Matlab command line):
 
 ```matlab
 		function doc_about(ndi_calculation_obj)
@@ -184,7 +184,7 @@ see the documentation for the calculation, and gives programmers/users a consist
 
 Putting it all together, we can look at the entire calculation:
 
-#### Code block 7.2.3.5: Full object code for [ndi.calc.example.simple](https://vh-lab.github.io/NDI-matlab/reference/%2Bndi/%2Bcalc/%2Bexample/simple.m/):
+#### Code block 7.2.3.5: Full object code for [ndi.calc.example.simple](https://vh-lab.github.io/NDI-matlab/NDI-matlab/reference/%2Bndi/%2Bcalc/%2Bexample/simple.m/):
 
 ```matlab
 classdef simple < ndi.calculation
@@ -291,7 +291,7 @@ D{1}.document_properties.simple, % should be struct with field 'answer' == 5
 D{1}.document_properties.depends_on  % should have name of 'probe_id'
 ```
 
-The other way to call a calculation is to use a very targeted set of parameters. If you want to perform your calculation only on specific items, such in the case of [ndi.calc.example.simple](https://vh-lab.github.io/NDI-matlab/reference/%2Bndi/%2Bcalc/%2Bexample/simple.m/),
+The other way to call a calculation is to use a very targeted set of parameters. If you want to perform your calculation only on specific items, such in the case of [ndi.calc.example.simple](https://vh-lab.github.io/NDI-matlab/NDI-matlab/reference/%2Bndi/%2Bcalc/%2Bexample/simple.m/),
 a specific probe or probes, then you can do that, too, by specifying the specific inputs that you want to search for. 
 
 #### Code block 7.3.1.4 Running the calculation, asking the program to find a specific input to the calculation (type into the Matlab command line).
@@ -308,7 +308,7 @@ d2{1}.document_properties.simple, % should be struct with field 'answer' == 5
 d2{1}.document_properties.depends_on  % should have name of 'probe_id' and p{1}'s probe id
 ```
 
-One can use some additional queries to find specific or parameterized documents to use as inputs for a calculation. See `help ndi.calculation.search_for_input_parameters` or look at the [ndi.calculation](https://vh-lab.github.io/NDI-matlab/reference/%2Bndi/calculation.m/) help page.
+One can use some additional queries to find specific or parameterized documents to use as inputs for a calculation. See `help ndi.calculation.search_for_input_parameters` or look at the [ndi.calculation](https://vh-lab.github.io/NDI-matlab/NDI-matlab/reference/%2Bndi/calculation.m/) help page.
 
 ### 7.1.6 Discussion/Feedback
 


### PR DESCRIPTION
I encounter a lot of broken links in the documentation, for example:
https://vh-lab.github.io/NDI-matlab/installation/

The actual link should be:
https://vh-lab.github.io/NDI-matlab/NDI-matlab/installation/

I.e NDI-matlab appears twice in a row.

I have done a search and replace across all .md files replacing `https://vh-lab.github.io/NDI-matlab` with `https://vh-lab.github.io/NDI-matlab/NDI-matlab`