### PR TITLE
Improve warning reset

### DIFF
--- a/+ndi/+dataset/dir.m
+++ b/+ndi/+dataset/dir.m
@@ -23,12 +23,13 @@ classdef dir < ndi.dataset
             elseif nargin==2,
                 ndi_dataset_dir_obj.session = ndi.session.dir(reference, path_name);
             elseif nargin==3, % hidden third option
-                S = warning;
-                warning('off');
+                % Todo: Switch off specific warnings using warning ids
+                warningStruct = warning('off');
+                resetWarningCleanupObj = onCleanup(@() warning(warningStruct));
                 ndi_dataset_dir_obj.session = ndi.session.dir(reference, path_name);
                 mystruct = struct(ndi_dataset_dir_obj.session); % don't do this but we need to here
                 mystruct.database.add(docs);
-                warning(S);
+                clear resetWarningCleanupObj
                 ndi_dataset_dir_obj.session = ndi.session.dir(reference, path_name);
             end;
 


### PR DESCRIPTION
Just a small fix, I ended up having all my warnings turned off because I errored out of the code before the warnings were reset (in `ndi.dataset.dir`)