### PR TITLE
Update test workflow to support running manually with release selection

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -17,6 +17,22 @@ on:
       
   # Allows for manually running this workflow from the Actions tab
   workflow_dispatch:
+    inputs:
+      matlab_release:
+        description: 'MATLAB Release'
+        required: false
+        default: 'latest'
+        type: choice
+        options:
+          - 'latest'
+          - 'R2025a'
+          - 'R2024b'
+          - 'R2024a'
+          - 'R2023b'
+          - 'R2023a'
+          - 'R2022b'
+          - 'R2022a'
+          - 'R2021b'
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -24,7 +40,7 @@ concurrency:
 
 jobs:
   run_tests:
-    name: Run tests (MATLAB latest release)
+    name: Run tests (MATLAB ${{ inputs.matlab_release || 'latest' }})
     runs-on: ubuntu-latest
     steps:      
       - name: Check out repo
@@ -40,7 +56,7 @@ jobs:
       - name: Set up MATLAB
         uses: matlab-actions/setup-matlab@v2
         with:
-          release: latest
+          release: ${{ inputs.matlab_release || 'latest' }}
           cache: true
 
       - name: Install MatBox


### PR DESCRIPTION
Update test workflow to support selecting a specific MATLAB release when running tests manually