### PR TITLE
Fix dimension mismatch in ListDatasetDocumentsAll document concatenation

### DIFF
--- a/src/ndi/+ndi/+cloud/+api/+implementation/+documents/ListDatasetDocumentsAll.m
+++ b/src/ndi/+ndi/+cloud/+api/+implementation/+documents/ListDatasetDocumentsAll.m
@@ -149,7 +149,7 @@ classdef ListDatasetDocumentsAll < ndi.cloud.api.call
                                 new_ids = string({new_docs.id});
                                 [~, new_indices] = setdiff(new_ids, existing_ids);
                                 if ~isempty(new_indices)
-                                    answer = cat(1, answer(:), new_docs(new_indices));
+                                    answer = cat(1, answer(:), reshape(new_docs(new_indices), [], 1));
                                 end
                             else
                                 answer = cat(1, answer(:), new_docs(:));


### PR DESCRIPTION
Fixes a rare error where `ListDatasetDocumentsAll` would fail during update checks if multiple new documents were found, due to a dimension mismatch in `cat`. The fix ensures the appended documents are always treated as a column vector.

---
*PR created automatically by Jules for task [12022392178861214516](https://jules.google.com/task/12022392178861214516) started by @stevevanhooser*