### PR TITLE
Add CI workflow for NDI symmetry tests

### DIFF
--- a/.github/workflows/test-symmetry.yml
+++ b/.github/workflows/test-symmetry.yml
@@ -66,11 +66,22 @@ jobs:
             assert(~isempty(suite), "No symmetry tests were found. Check tests/+ndi/+symmetry.")
 
             runner = TestRunner.withTextOutput("Verbosity", "Detailed");
-            results = runner.run(suite);
 
-            fprintf("\n=== Symmetry Test Results ===\n");
-            fprintf("  %d passed, %d failed, %d incomplete\n", ...
-                nnz([results.Passed]), nnz([results.Failed]), nnz([results.Incomplete]));
+            nMake = numel(makeSuite);
+            nRead = numel(readSuite);
+
+            makeResults = runner.run(makeSuite);
+            fprintf("\n=== makeArtifacts Results: %d passed, %d failed, %d incomplete out of %d ===\n", ...
+                nnz([makeResults.Passed]), nnz([makeResults.Failed]), nnz([makeResults.Incomplete]), nMake);
+
+            readResults = runner.run(readSuite);
+            fprintf("\n=== readArtifacts Results: %d passed, %d failed, %d incomplete out of %d ===\n", ...
+                nnz([readResults.Passed]), nnz([readResults.Failed]), nnz([readResults.Incomplete]), nRead);
+
+            results = [makeResults, readResults];
+            fprintf("\n=== Overall Symmetry Test Results ===\n");
+            fprintf("  %d passed, %d failed, %d incomplete out of %d total\n", ...
+                nnz([results.Passed]), nnz([results.Failed]), nnz([results.Incomplete]), numel(results));
             disp(table(results));
 
             assert(all(~[results.Failed]), "Some symmetry tests failed")


### PR DESCRIPTION
## Summary
This PR adds a new GitHub Actions workflow to automatically run NDI symmetry tests on every push to main and pull request.

## Key Changes
- Added `.github/workflows/test-symmetry.yml` workflow that:
  - Runs on push to main, pull requests to main, and manual dispatch
  - Sets up a virtual display server (Xvfb) for Linux environments
  - Installs MATLAB with required toolboxes (Communications, Statistics and Machine Learning, Signal Processing)
  - Installs MatBox for dependency management
  - Authenticates with NDI cloud using secrets
  - Runs the symmetry test suite from `tests/+ndi/+symmetry`
  - Fails the workflow if any tests fail
  - Cleans up MATLAB path on completion

## Notable Details
- Uses concurrency controls to cancel in-progress runs when new commits are pushed
- Leverages MATLAB Actions for setup and test execution
- Requires NDI cloud credentials stored as GitHub secrets (`NDI_CLOUD_USERNAME`, `NDI_CLOUD_PASSWORD`)
- Includes proper cleanup step that runs regardless of test outcome

https://claude.ai/code/session_01JVU7jECnncEjk2ruCHujbN