### PR TITLE
Make session summary comparison order-independent for struct arrays

### DIFF
--- a/src/ndi/+ndi/+util/compareSessionSummary.m
+++ b/src/ndi/+ndi/+util/compareSessionSummary.m
@@ -112,6 +112,10 @@ for i = 1:numel(common_fields)
             continue;
         end
 
+        % Sort struct arrays so comparison is order-independent
+        val1 = sortStructArrayBySerialization(val1);
+        val2 = sortStructArrayBySerialization(val2);
+
         for j = 1:numel(val1)
             sub_report = ndi.util.compareSessionSummary(val1(j), val2(j));
             for k = 1:numel(sub_report)
@@ -173,6 +177,19 @@ for i = 1:numel(common_fields)
     end
 end
 
+end
+
+function s = sortStructArrayBySerialization(s)
+% SORTSTRUCTARRAYBYSERIALIZATION - sort a struct array by JSON key for each element
+    if numel(s) <= 1
+        return;
+    end
+    keys = cell(1, numel(s));
+    for idx = 1:numel(s)
+        keys{idx} = jsonencode(s(idx));
+    end
+    [~, order] = sort(keys);
+    s = s(order);
 end
 
 function c = sortCellBySerialization(c)


### PR DESCRIPTION
## Summary
This change makes the `compareSessionSummary` function order-independent when comparing struct arrays by sorting them before comparison.

## Key Changes
- Added `sortStructArrayBySerialization()` helper function that sorts struct arrays by their JSON serialization, ensuring consistent ordering regardless of input order
- Modified the struct array comparison logic to sort both struct arrays before element-by-element comparison
- This prevents false differences from being reported when struct arrays contain the same elements in different orders

## Implementation Details
The new `sortStructArrayBySerialization()` function:
- Returns early if the struct array has 0 or 1 elements (already sorted)
- Serializes each struct element to JSON to create comparable keys
- Uses MATLAB's `sort()` function to determine the reordering
- Applies the sorted order to the struct array

This approach mirrors the existing `sortCellBySerialization()` function pattern and ensures that session summary comparisons are robust to element ordering differences.

https://claude.ai/code/session_01Q66pasorWAQcZXjauKuDXG