### PR TITLE
Make dataset directory detection dynamic in artifact tests

### DIFF
--- a/tests/+ndi/+symmetry/+makeArtifacts/+dataset/downloadIngested.m
+++ b/tests/+ndi/+symmetry/+makeArtifacts/+dataset/downloadIngested.m
@@ -27,10 +27,14 @@ classdef downloadIngested < matlab.unittest.TestCase
             % Extract the archive into the artifact directory
             untar(tgzFile, artifactDir);
 
-            % The extracted directory is an ndi.dataset.dir object
-            datasetPath = fullfile(artifactDir, '69a8705aa9ab25373cdc6563');
+            % Find the extracted directory (expect exactly one folder)
+            entries = dir(artifactDir);
+            subdirs = entries([entries.isdir] & ~ismember({entries.name}, {'.', '..'}));
+            testCase.verifyEqual(numel(subdirs), 1, ...
+                sprintf('Expected exactly one directory in extracted archive, found %d.', numel(subdirs)));
+            datasetPath = fullfile(artifactDir, subdirs(1).name);
             testCase.verifyTrue(isfolder(datasetPath), ...
-                'Expected extracted directory 69a8705aa9ab25373cdc6563 not found.');
+                'Expected extracted dataset directory not found.');
 
             % Open the dataset
             dataset = ndi.dataset.dir(datasetPath);

--- a/tests/+ndi/+symmetry/+readArtifacts/+dataset/downloadIngested.m
+++ b/tests/+ndi/+symmetry/+readArtifacts/+dataset/downloadIngested.m
@@ -28,8 +28,12 @@ classdef downloadIngested < matlab.unittest.TestCase
             fclose(fid);
             expectedSummary = jsondecode(rawJson);
 
-            % The downloaded dataset lives inside the artifact directory
-            datasetPath = fullfile(artifactDir, '69a8705aa9ab25373cdc6563');
+            % Find the dataset directory (expect exactly one folder)
+            entries = dir(artifactDir);
+            subdirs = entries([entries.isdir] & ~ismember({entries.name}, {'.', '..'}));
+            testCase.verifyEqual(numel(subdirs), 1, ...
+                ['Expected exactly one directory in ' SourceType ' artifacts, found ' num2str(numel(subdirs)) '.']);
+            datasetPath = fullfile(artifactDir, subdirs(1).name);
             testCase.verifyTrue(isfolder(datasetPath), ...
                 ['Expected dataset directory not found in ' SourceType ' artifacts.']);
 


### PR DESCRIPTION
## Summary
Updated artifact download tests to dynamically detect the extracted dataset directory instead of relying on a hardcoded directory name. This makes the tests more robust and maintainable.

## Key Changes
- Replaced hardcoded directory name `'69a8705aa9ab25373cdc6563'` with dynamic detection logic in both test files
- Added directory enumeration to find subdirectories in the artifact directory
- Added verification that exactly one subdirectory exists in the extracted archive
- Updated error messages to be more generic and informative

## Implementation Details
- Uses `dir()` to list all entries in the artifact directory
- Filters for directories while excluding `.` and `..` entries using `[entries.isdir] & ~ismember({entries.name}, {'.', '..'})`
- Verifies exactly one subdirectory is found before proceeding
- Constructs the dataset path using the dynamically discovered directory name
- Applied the same pattern consistently across both test files (`makeArtifacts` and `readArtifacts`)

https://claude.ai/code/session_019oshYeLBF9TE9Q96SreiAG