### PR TITLE
Remove macOS resource fork files from extracted artifacts

### DIFF
--- a/tests/+ndi/+symmetry/+makeArtifacts/+dataset/downloadIngested.m
+++ b/tests/+ndi/+symmetry/+makeArtifacts/+dataset/downloadIngested.m
@@ -27,6 +27,13 @@ classdef downloadIngested < matlab.unittest.TestCase
             % Extract the archive into the artifact directory
             untar(tgzFile, artifactDir);
 
+            % Remove macOS resource fork files (._*) that may be in the archive;
+            % these are invisible metadata files and should not appear in file listings.
+            dotUnderscoreFiles = dir(fullfile(artifactDir, '**', '._*'));
+            for k = 1:numel(dotUnderscoreFiles)
+                delete(fullfile(dotUnderscoreFiles(k).folder, dotUnderscoreFiles(k).name));
+            end
+
             % Find the extracted directory (expect exactly one folder)
             entries = dir(artifactDir);
             subdirs = entries([entries.isdir] & ~ismember({entries.name}, {'.', '..'}));


### PR DESCRIPTION
## Summary
Added cleanup logic to remove macOS resource fork files (._* files) that may be present in extracted tar archives. These invisible metadata files should not appear in file listings and can cause issues with subsequent directory scanning.

## Key Changes
- Added code to detect and delete all `._*` resource fork files after extracting the artifact archive
- Uses recursive directory search (`**` pattern) to find these files at any depth within the artifact directory
- Executes the cleanup before the subsequent directory listing operation that expects only the actual extracted content

## Implementation Details
- The cleanup iterates through all matched resource fork files and deletes them individually
- This prevents these macOS-specific metadata files from interfering with the test's expectation of finding exactly one subdirectory in the artifact folder
- The solution is non-destructive to actual artifact content and only targets the unwanted metadata files

https://claude.ai/code/session_01ADRvpgkjR8fFY6ZQ3y4TmF