### PR TITLE
Default uploads to curl with pinned headers

### DIFF
--- a/src/ndi/+ndi/+cloud/+api/+files/putFiles.m
+++ b/src/ndi/+ndi/+cloud/+api/+files/putFiles.m
@@ -14,8 +14,10 @@ function [b, answer, apiResponse, apiURL] = putFiles(preSignedURL, filePath, opt
 %   Name-Value Pairs:
 %       'useCurl' (logical) - If true, the function will use a system call
 %                             to the `curl` command-line tool to perform the
-%                             upload. This can be a robust fallback if the native
-%                             MATLAB HTTP client fails. Defaults to false.
+%                             upload. Defaults to true so every upload path
+%                             stores objects in S3 with consistent headers
+%                             (the MATLAB HTTP client can tag objects
+%                             differently, producing flaky downloads).
 %
 %   Outputs:
 %       b            - True if the upload succeeded (HTTP 200), false otherwise.
@@ -39,7 +41,7 @@ function [b, answer, apiResponse, apiURL] = putFiles(preSignedURL, filePath, opt
     arguments
         preSignedURL (1,1) string
         filePath (1,1) string {mustBeFile}
-        options.useCurl (1,1) logical = false
+        options.useCurl (1,1) logical = true
     end
     % 1. Create an instance of the implementation class, passing the options.
     api_call = ndi.cloud.api.implementation.files.PutFiles(...
@@ -51,4 +53,3 @@ function [b, answer, apiResponse, apiURL] = putFiles(preSignedURL, filePath, opt
     [b, answer, apiResponse, apiURL] = api_call.execute();
     
 end
-

--- a/src/ndi/+ndi/+cloud/+api/+implementation/+files/PutFiles.m
+++ b/src/ndi/+ndi/+cloud/+api/+implementation/+files/PutFiles.m
@@ -16,7 +16,7 @@ classdef PutFiles
             arguments
                 args.preSignedURL (1,1) string
                 args.filePath (1,1) string {mustBeFile}
-                args.useCurl (1,1) logical = false
+                args.useCurl (1,1) logical = true
             end
             this.preSignedURL = args.preSignedURL;
             this.filePath = args.filePath;
@@ -62,9 +62,16 @@ classdef PutFiles
             % Implementation using a system call to curl
             b = false;
             apiURL = this.preSignedURL; % Return the URL as a string
-            
-            command = sprintf('curl -X PUT --upload-file "%s" "%s"', this.filePath, this.preSignedURL);
-            
+
+            % -f so HTTP errors (403/404 on a stale signed URL, etc.) surface
+            % as a non-zero exit. Pin Content-Type to application/octet-stream
+            % and Accept-Encoding to identity so the object metadata stored in
+            % S3 is predictable regardless of the client's environment.
+            command = sprintf(['curl -fsSL -X PUT --upload-file "%s" ' ...
+                '-H "Content-Type: application/octet-stream" ' ...
+                '-H "Accept-Encoding: identity" ' ...
+                '"%s"'], this.filePath, this.preSignedURL);
+
             [status, result] = system(command);
             
             b = (status == 0);
@@ -75,4 +82,3 @@ classdef PutFiles
         end
     end
 end
-

--- a/src/ndi/+ndi/+cloud/uploadSingleFile.m
+++ b/src/ndi/+ndi/+cloud/uploadSingleFile.m
@@ -40,7 +40,7 @@ function [b, errormsg] = uploadSingleFile(cloudDatasetID, cloudFileUID, filePath
                 error(['Could not get file collection upload URL: ' url_or_error.message]);
             end
 
-            [b_put, put_or_error] = ndi.cloud.api.files.putFiles(url_or_error, zip_file);
+            [b_put, put_or_error] = ndi.cloud.api.files.putFiles(url_or_error, zip_file, 'useCurl', options.useCurl);
             if ~b_put
                 error(['Could not upload zip file: ' put_or_error.message]);
             end


### PR DESCRIPTION
## Summary
- Default `ndi.cloud.api.files.putFiles` (and the underlying `PutFiles` implementation class) to `useCurl = true`, matching the curl-by-default we already landed on downloads.
- Pin upload headers in the curl path to `Content-Type: application/octet-stream` and `Accept-Encoding: identity` so the object metadata stored by S3 is identical no matter which client issued the PUT. Add `-f` so stale signed URLs (403/404) fail loudly instead of being reported as a successful upload.
- Forward `options.useCurl` from `uploadSingleFile`'s bulk-upload branch (previously only the non-bulk branch forwarded it, so bulk uploads silently used the MATLAB HTTP path).

## Why
Audit of the upload paths showed several places still using MATLAB's native HTTP stack (`zipForUpload`, `uploadDocumentCollection` batch, `uploadSingleFile` bulk branch, anything calling `putFiles` without `useCurl`). Different clients tag S3 objects with different headers, which is the most plausible explanation for the flaky "Invalid TAR file" errors on freshly-uploaded `.tgz` artifacts — object metadata varies depending on which code path performed the upload. Standardizing on curl with pinned headers makes the stored metadata deterministic and matches the download side.

## Test plan
- [ ] Re-run `ndi.unittest.cloud.readIngested` on Linux and Mac.
- [ ] Re-run `ndi.symmetry.makeArtifacts.dataset.downloadIngested/testDownloadIngestedArtifacts` on Linux.
- [ ] Spot-check `aws s3api head-object` on a freshly-uploaded `.tgz` to confirm `ContentType: application/octet-stream` and no `ContentEncoding` metadata.

https://claude.ai/code/session_01HMnM1qnDBgGdjSqSnjTfsV