### PR TITLE
Refactor stimulus on/off pairing to handle clipped events

### DIFF
--- a/src/ndi/+ndi/+probe/+timeseries/stimulator.m
+++ b/src/ndi/+ndi/+probe/+timeseries/stimulator.m
@@ -121,8 +121,9 @@ classdef stimulator < ndi.probe.timeseries
                             mk_ = mk_ + 1;
                             switch mk_
                                 case 1 % stimonoff
-                                    t.stimon = timestamps{i}(find(edata{i}(:,1)>0),1);
-                                    t.stimoff = timestamps{i}(find(edata{i}(:,1)==-1),1);
+                                    [t.stimon, t.stimoff] = ...
+                                        ndi.probe.timeseries.stimulator.pairOnOff(...
+                                            timestamps{i}(:,1), edata{i}(:,1));
                                 case 2 % stimid
                                     for dd=1:size(edata{i},1)
                                         if strcmp(channeltype{i},'text')
@@ -132,14 +133,12 @@ classdef stimulator < ndi.probe.timeseries
                                         end
                                     end
                                 case 3 % stimopenclose
-                                    on_ = timestamps{i}( find(edata{i}(:,1)>0) , 1);
-                                    off_ = timestamps{i}( find(edata{i}(:,1)==-1) , 1);
-                                    if numel(on_)>0
-                                        t.stimopenclose(1:numel(on_),1) = on_;
-                                    end
-                                    if numel(off_)>0
-                                        t.stimopenclose(1:numel(off_),2) = off_;
-                                        if isempty(t.stimoff), t.stimoff = off_; end
+                                    [open_, close_] = ...
+                                        ndi.probe.timeseries.stimulator.pairOnOff(...
+                                            timestamps{i}(:,1), edata{i}(:,1));
+                                    t.stimopenclose = [open_ close_];
+                                    if isempty(t.stimoff)
+                                        t.stimoff = close_;
                                     end
                                 otherwise
                                     error(['Got more mark channels than expected.']);
@@ -162,9 +161,11 @@ classdef stimulator < ndi.probe.timeseries
                 for i=1:numel(edata)
                     if ~isempty(intersect(channeltype(i),{'dimp','dimn'}))
                         counter = counter + 1;
-                        t.stimon = [t.stimon(:); vlt.data.colvec(timestamps{i}(find(edata{i}(:,1)>0),1))];
-                        t.stimoff = [t.stimoff(:); vlt.data.colvec(edata{i}(find(edata{i}(:,1)==-1),1))];
-                        data.stimid = [data.stimid(:); counter*ones(numel(find(edata{i}(:,1)==1)),1)];
+                        [on_i, off_i] = ndi.probe.timeseries.stimulator.pairOnOff(...
+                            timestamps{i}(:,1), edata{i}(:,1));
+                        t.stimon  = [t.stimon(:);  on_i];
+                        t.stimoff = [t.stimoff(:); off_i];
+                        data.stimid = [data.stimid(:); counter*ones(numel(on_i),1)];
                     end
                     if strcmp(channeltype(i),'md')
                         data.parameters = getmetadata(dev{1},devepoch{1},channel(i));
@@ -173,7 +174,12 @@ classdef stimulator < ndi.probe.timeseries
                         event_data{end+1} = timestamps{i};
                     end
                 end
-                [dummy,order] = sort(t.stimon);
+                % NaN-on entries represent stims that began before the window;
+                % sort them by their off-time so they stay in temporal order.
+                sort_key = t.stimon;
+                nan_on = isnan(sort_key);
+                sort_key(nan_on) = t.stimoff(nan_on);
+                [~,order] = sort(sort_key);
                 t.stimon = t.stimon(order(:));
                 t.stimoff = t.stimoff(order(:));
                 data.stimid = data.stimid(order(:));
@@ -185,4 +191,49 @@ classdef stimulator < ndi.probe.timeseries
         end %readtimeseriesepoch()
 
     end % methods
+
+    methods (Static, Access=public)
+        function [on, off] = pairOnOff(times, signs)
+            % PAIRONOFF - Pair stimulus on/off events, NaN-filling orphans.
+            %
+            % [ON, OFF] = pairOnOff(TIMES, SIGNS) takes a column of event
+            % times TIMES and a column of marker values SIGNS (>0 means
+            % stim-on, <0 means stim-off) and returns equal-length column
+            % vectors ON and OFF of paired times.
+            %
+            % Events are walked in time order. A stim-on is paired with the
+            % next stim-off; a stim-on with no following off (clipped by the
+            % read window) gets OFF=NaN, and a stim-off with no preceding on
+            % gets ON=NaN. This lets callers read partial intervals without
+            % erroring on mismatched event counts (issue #248).
+            times = times(:);
+            signs = sign(signs(:));
+            [times, ord] = sort(times);
+            signs = signs(ord);
+
+            n = numel(signs);
+            on  = nan(n,1);
+            off = nan(n,1);
+            p = 0;
+            k = 1;
+            while k <= n
+                if signs(k) > 0
+                    p = p + 1;
+                    on(p) = times(k);
+                    if k+1 <= n && signs(k+1) < 0
+                        off(p) = times(k+1);
+                        k = k + 2;
+                    else
+                        k = k + 1;
+                    end
+                else
+                    p = p + 1;
+                    off(p) = times(k);
+                    k = k + 1;
+                end
+            end
+            on  = on(1:p);
+            off = off(1:p);
+        end
+    end % static methods
 end

--- a/tests/+ndi/+unittest/+probe/StimulatorTest.m
+++ b/tests/+ndi/+unittest/+probe/StimulatorTest.m
@@ -50,6 +50,56 @@ classdef StimulatorTest < matlab.unittest.TestCase
     end
 
     methods (Test)
+        function testPairOnOffMatched(testCase)
+            t = [1; 2; 3; 4];
+            s = [1; -1; 1; -1];
+            [on, off] = ndi.probe.timeseries.stimulator.pairOnOff(t, s);
+            testCase.verifyEqual(on,  [1;3]);
+            testCase.verifyEqual(off, [2;4]);
+        end
+
+        function testPairOnOffTrailingOn(testCase)
+            % stim still on when window closes: trailing on with no off
+            t = [1; 2; 3];
+            s = [1; -1; 1];
+            [on, off] = ndi.probe.timeseries.stimulator.pairOnOff(t, s);
+            testCase.verifyEqual(on,  [1;3]);
+            testCase.verifyEqual(off, [2;NaN]);
+        end
+
+        function testPairOnOffLeadingOff(testCase)
+            % stim already on when window opens: leading off with no on
+            t = [1; 2; 3];
+            s = [-1; 1; -1];
+            [on, off] = ndi.probe.timeseries.stimulator.pairOnOff(t, s);
+            testCase.verifyEqual(on,  [NaN;2]);
+            testCase.verifyEqual(off, [1;3]);
+        end
+
+        function testPairOnOffBothClipped(testCase)
+            t = [1; 2; 3; 4; 5];
+            s = [-1; 1; -1; 1; -1];
+            [on, off] = ndi.probe.timeseries.stimulator.pairOnOff(t, s);
+            testCase.verifyEqual(on,  [NaN;2;4]);
+            testCase.verifyEqual(off, [1;3;5]);
+        end
+
+        function testPairOnOffEmpty(testCase)
+            [on, off] = ndi.probe.timeseries.stimulator.pairOnOff(...
+                zeros(0,1), zeros(0,1));
+            testCase.verifyEmpty(on);
+            testCase.verifyEmpty(off);
+            testCase.verifyEqual(numel(on), numel(off));
+        end
+
+        function testPairOnOffUnsorted(testCase)
+            t = [3; 1; 4; 2];
+            s = [1; 1; -1; -1];
+            [on, off] = ndi.probe.timeseries.stimulator.pairOnOff(t, s);
+            testCase.verifyEqual(on,  [1;3]);
+            testCase.verifyEqual(off, [2;4]);
+        end
+
         function testReadTimeSeries(testCase)
             % Get the probe
             p = testCase.Session.getprobes();


### PR DESCRIPTION
## Summary
This PR refactors the stimulus on/off event pairing logic in the stimulator probe to handle cases where stimulus events are clipped by the read window boundaries. Previously, the code assumed all on-events would have corresponding off-events and vice versa, which caused issues when reading partial time intervals.

Closes #248

## Key Changes
- **New static method `pairOnOff()`**: Extracted the on/off pairing logic into a reusable static method that:
  - Pairs stimulus on-events (positive markers) with their corresponding off-events (negative markers)
  - Handles orphaned events by filling with NaN values:
    - Stimulus still on when window closes → OFF=NaN
    - Stimulus already on when window opens → ON=NaN
  - Processes events in temporal order regardless of input order
  - Returns equal-length column vectors for ON and OFF times

- **Updated `readtimeseriesepoch()` method**: Replaced three separate inline implementations with calls to the new `pairOnOff()` method:
  - Case 1 (stimonoff): Simplified from manual find/indexing to single function call
  - Case 3 (stimopenclose): Refactored to use `pairOnOff()` and handle NaN values properly
  - DIM channel processing: Consolidated on/off extraction logic

- **Improved sorting logic**: Enhanced the sort key calculation to handle NaN on-times by using off-times as a fallback, ensuring proper temporal ordering of partially-clipped stimuli

- **Comprehensive test coverage**: Added 6 unit tests covering:
  - Matched on/off pairs
  - Trailing on-events (clipped at window end)
  - Leading off-events (clipped at window start)
  - Both clipped scenarios
  - Empty input
  - Unsorted input

## Implementation Details
The `pairOnOff()` method uses a single-pass algorithm that walks through time-sorted events, maintaining a counter `p` for output pairs. It handles the three cases:
1. On-event followed by off-event → pair them
2. On-event not followed by off-event → pair with NaN
3. Off-event without preceding on-event → pair with NaN

This approach resolves issue #248 by allowing callers to read partial time windows without errors due to mismatched event counts.

https://claude.ai/code/session_013Ytz2pbcyedGPiccj8jkpT