### PR TITLE
Improve API error handling with robust formatApiError utility

### DIFF
--- a/src/ndi/+ndi/+cloud/+internal/formatApiError.m
+++ b/src/ndi/+ndi/+cloud/+internal/formatApiError.m
@@ -1,0 +1,46 @@
+function msg = formatApiError(apiResponse)
+% FORMATAPIERROR - Build a human-readable error message from an HTTP response.
+%
+%   MSG = ndi.cloud.internal.formatApiError(APIRESPONSE)
+%
+%   Returns a non-empty char message describing the failed API call. Tolerates
+%   APIRESPONSE being empty, missing a body, or having a body that is not a
+%   struct with a 'message' field (the conditions that caused #624).
+
+    if isempty(apiResponse) || ~isa(apiResponse, 'matlab.net.http.ResponseMessage')
+        msg = 'no response from server';
+        return;
+    end
+
+    statusPart = '';
+    try
+        statusPart = sprintf('HTTP %d', double(apiResponse.StatusCode));
+        if ~isempty(apiResponse.StatusLine) && ~isempty(apiResponse.StatusLine.ReasonPhrase)
+            statusPart = sprintf('%s %s', statusPart, char(apiResponse.StatusLine.ReasonPhrase));
+        end
+    catch
+    end
+
+    bodyPart = '';
+    try
+        data = apiResponse.Body.Data;
+        if isstruct(data) && isfield(data, 'message') && ~isempty(data.message)
+            bodyPart = char(string(data.message));
+        elseif isstruct(data) && isfield(data, 'error') && ~isempty(data.error)
+            bodyPart = char(string(data.error));
+        elseif ischar(data) || isstring(data)
+            bodyPart = char(string(data));
+        end
+    catch
+    end
+
+    if ~isempty(statusPart) && ~isempty(bodyPart)
+        msg = sprintf('%s - %s', statusPart, bodyPart);
+    elseif ~isempty(statusPart)
+        msg = statusPart;
+    elseif ~isempty(bodyPart)
+        msg = bodyPart;
+    else
+        msg = 'unknown error';
+    end
+end

--- a/src/ndi/+ndi/+cloud/uploadDataset.m
+++ b/src/ndi/+ndi/+cloud/uploadDataset.m
@@ -79,12 +79,12 @@ function [success, cloudDatasetId, message] = uploadDataset(ndiDataset, syncOpti
         end
 
         %   Step 1c: Create new NDI Cloud Dataset
-        [success_create, cloudDatasetId_or_err] = ndi.cloud.api.datasets.createDataset(cloud_dataset_info);
+        [success_create, newCloudDatasetId, apiResponse] = ndi.cloud.api.datasets.createDataset(cloud_dataset_info);
         if ~success_create
-            message = ['Failed to create dataset: ' cloudDatasetId_or_err.message];
+            message = ['Failed to create dataset: ' ndi.cloud.internal.formatApiError(apiResponse)];
             return;
         end
-        cloudDatasetId = cloudDatasetId_or_err;
+        cloudDatasetId = newCloudDatasetId;
 
         % Add document with remote dataset id to dataset before uploading.
         remoteDatasetDoc = ndi.cloud.internal.createRemoteDatasetDoc(cloudDatasetId, ndiDataset);


### PR DESCRIPTION
Closes #624

## Summary
This PR improves error handling in the NDI Cloud API integration by introducing a robust error formatting utility and updating the dataset upload flow to use it.

## Key Changes
- **New utility function**: Added `ndi.cloud.internal.formatApiError()` that safely extracts and formats error messages from HTTP responses
  - Handles missing or malformed responses gracefully
  - Supports multiple error message formats (struct with 'message' or 'error' fields, or plain text)
  - Always returns a non-empty human-readable error message
  - Addresses issue #624 by tolerating edge cases that previously caused failures

- **Updated `uploadDataset.m`**: Refactored error handling in the dataset creation step
  - Changed `createDataset()` call to return the API response object in addition to success status and dataset ID
  - Replaced direct error message access with call to `formatApiError()` for consistent, robust error reporting
  - Improved variable naming for clarity (`cloudDatasetId_or_err` → `newCloudDatasetId`)

## Implementation Details
The `formatApiError()` function builds error messages with a priority order:
1. HTTP status code + reason phrase + body message (if all available)
2. HTTP status code + reason phrase (if body unavailable)
3. Body message alone (if status unavailable)
4. Generic "unknown error" fallback

All field accesses are wrapped in try-catch blocks to ensure the function never fails, even with unexpected response structures.

https://claude.ai/code/session_01QdT7No5rGRxLe9gykVUbfK