### PR TITLE
Tolerate heterogeneous file entries in ListFiles.execute (#807)

### DIFF
--- a/src/ndi/+ndi/+cloud/+api/+implementation/+files/ListFiles.m
+++ b/src/ndi/+ndi/+cloud/+api/+implementation/+files/ListFiles.m
@@ -45,16 +45,38 @@ classdef ListFiles < ndi.cloud.api.call
                     return;
                 end
 
-                % Check if the 'files' field exists and is not empty
+                % Check if the 'files' field exists and is not empty.
+                % jsondecode returns dsetInfo.files as a struct array when
+                % every entry has the same field set, and as a cell array of
+                % structs when entries have heterogeneous field sets. The
+                % loop tolerates both shapes; missing optional fields on a
+                % single entry (uploaded / sourceDatasetId / size) are
+                % filled with defaults so one weirdly-shaped server response
+                % cannot break the whole listing. See VH-Lab/NDI-matlab#807.
                 if ~isempty(dsetInfo) && isfield(dsetInfo, 'files') && ~isempty(dsetInfo.files)
                     for i = 1:numel(dsetInfo.files)
-                        file = dsetInfo.files(i);
+                        if iscell(dsetInfo.files)
+                            file = dsetInfo.files{i};
+                        else
+                            file = dsetInfo.files(i);
+                        end
+                        if ~isstruct(file) || ~isfield(file, 'uid') || isempty(file.uid)
+                            continue;
+                        end
                         if ~isKey(fileMap, file.uid)
-                            fileMap(file.uid) = struct(...
+                            entry = struct( ...
                                 'uid', file.uid, ...
-                                'uploaded', file.uploaded, ...
-                                'sourceDatasetId', file.sourceDatasetId, ...
-                                'size', file.size);
+                                'uploaded', [], ...
+                                'sourceDatasetId', '', ...
+                                'size', []);
+                            optionalFields = ["uploaded", "sourceDatasetId", "size"];
+                            for k = 1:numel(optionalFields)
+                                fname = char(optionalFields(k));
+                                if isfield(file, fname)
+                                    entry.(fname) = file.(fname);
+                                end
+                            end
+                            fileMap(file.uid) = entry;
                         end
                     end
                 end


### PR DESCRIPTION
ndi.cloud.api.implementation.files.ListFiles.execute assumed dsetInfo.files is always a struct array and indexed it with (i). jsondecode actually returns a cell array when entries have different field sets, so (i) returns a 1x1 cell and the next line's file.uid errors with 'Dot indexing is not supported for variables of type cell'. The whole listFiles call dies.

PR #806 makes this reachable in practice: a fresh upload lands in the file list alongside older entries decorated slightly differently by the API, and the next listFiles call hits the cell-array branch.

Fix:
- Use {i} when dsetInfo.files is a cell, (i) when it is a struct array.
- Skip entries that aren't a struct or lack a uid so one bad entry can't take down the listing.
- Build the per-entry struct field-by-field with defaults so a missing optional field (uploaded, sourceDatasetId, size) is filled rather than crashing.

Verified original failure mode on R2026a after a fresh upload, and confirmed the new loop returns a complete listing without errors. See #807 for the reproduction trace."