### PR TITLE
Skip all hidden files and directories in epoch navigator

### DIFF
--- a/src/ndi/+ndi/+setup/+file/+navigator/vhlab_np_epochdir.m
+++ b/src/ndi/+ndi/+setup/+file/+navigator/vhlab_np_epochdir.m
@@ -123,7 +123,11 @@ classdef vhlab_np_epochdir < ndi.file.navigator.epochdir
                 stack(end) = [];
                 entries = dir(cur);
                 for i = 1:numel(entries)
-                    if strcmp(entries(i).name, '.') || strcmp(entries(i).name, '..')
+                    % Skip hidden entries (names beginning with '.'); this
+                    % also covers '.' and '..' and must not traverse
+                    % directories such as '.git' or other dot-directories
+                    % created by the OS or version control.
+                    if entries(i).name(1) == '.'
                         continue;
                     end
                     full = fullfile(cur, entries(i).name);


### PR DESCRIPTION
## Summary
Updated the epoch directory navigator to skip all hidden files and directories (those beginning with a dot) instead of only explicitly checking for '.' and '..' entries.

## Key Changes
- Replaced explicit string comparisons for '.' and '..' with a more general check for any entry name beginning with '.'
- This change prevents traversal into hidden directories such as `.git`, `.svn`, and other dot-directories created by version control systems or the operating system
- Added clarifying comments explaining the rationale for skipping hidden entries

## Implementation Details
- Changed from: `strcmp(entries(i).name, '.') || strcmp(entries(i).name, '..')`
- Changed to: `entries(i).name(1) == '.'`
- This is more efficient and comprehensive, catching all hidden files/directories in a single condition while maintaining the original behavior for '.' and '..'

https://claude.ai/code/session_01THiGxfqC5SkEYsSybexXMQ