### PR TITLE
Don't treat HTTP 504 as success in bulkDeleteDocuments

### DIFF
--- a/src/ndi/+ndi/+cloud/+api/+implementation/+documents/BulkDeleteDocuments.m
+++ b/src/ndi/+ndi/+cloud/+api/+implementation/+documents/BulkDeleteDocuments.m
@@ -72,7 +72,7 @@ classdef BulkDeleteDocuments < ndi.cloud.api.call
             
             apiResponse = send(request, apiURL);
             
-            if (apiResponse.StatusCode == 200 || apiResponse.StatusCode == 204 || apiResponse.StatusCode == 504)
+            if (apiResponse.StatusCode == 200 || apiResponse.StatusCode == 204)
                 b = true;
                 if ~isempty(apiResponse.Body.Data)
                     answer = apiResponse.Body.Data;


### PR DESCRIPTION
Closes #812.

## Summary

`bulkDeleteDocuments` treats HTTP 504 (Gateway Timeout) as success alongside 200/204. 504 means the upstream service did not respond in time, so the client cannot know whether the deletions reached the backend. Returning `b=true` with `answer = "Documents deleted."` silently masks deletions that may not have happened.

## Repro

A pulakat recovery session ran:

```matlab
[b, ans] = ndi.cloud.api.documents.bulkDeleteDocuments(datasetId, docIds);  % default when='7d'
% b == 1, ans.message == 'Documents deleted'
```

against 12 broken doc IDs. Immediately afterwards:

```matlab
[~, cloudDocs] = ndi.cloud.api.documents.listDatasetDocumentsAll(datasetId);
% all 12 still present
```

Re-calling with `when='now'` succeeded for real. The first call may have 504'd silently — with the current code we have no way to tell.

## Fix

Drop 504 from the success arm. Treat it like any other non-200/204: `b=false`, `answer = apiResponse.Body.Data` so the caller can see what happened. `ndi.cloud.api.documents.deleteDocument` (called from this class's `isscalar` fast path) does not special-case 504, so removing it here aligns the two paths.

## Test plan

- [ ] Existing `bulkDeleteDocuments` calls against a happy-path server (200/204) still succeed.
- [ ] A 504 response now returns `b=false`. (Hard to induce deliberately; the bug class is "we can't tell whether anything succeeded," so the test is mostly the inverted assertion at the existing call sites.)
- [ ] CI green.

## Related

Part of cloud-sync robustness umbrella #812. Sibling items:

- `uploadNew` discarding return codes — already resolved in #805.
- `listFiles` heterogeneous response — fixed in #808 (closes #807).
- `list_binary_files` crash — covered by #812 with a request-for-repro flag; not in scope for this PR.