### PR TITLE
Improve NDI_CLOUD_RUN_HELLO_MATLAB environment variable handling

### DIFF
--- a/tests/+ndi/+unittest/+cloud/+compute/HelloMatlabTest.m
+++ b/tests/+ndi/+unittest/+cloud/+compute/HelloMatlabTest.m
@@ -12,10 +12,12 @@ classdef HelloMatlabTest < matlab.unittest.TestCase
 %
 %   The test is opt-in via the NDI_CLOUD_RUN_HELLO_MATLAB env var because
 %   it spins up a real EC2 instance (~2-4 min, billable) and depends on
-%   the BYOL setup above. Without it, the test is assumed-failed with a
-%   message explaining how to enable it, so the suite does not silently
-%   skip license-verification coverage but also does not break the
-%   default cloud-api run.
+%   the BYOL setup above. It only runs when NDI_CLOUD_RUN_HELLO_MATLAB is
+%   set to a truthy value ("1" or "true", case insensitive); any other
+%   value (including "0", "false", or unset) is treated as opt-out and the
+%   test is skipped via assumeFail with a message explaining how to enable
+%   it. This way the suite does not silently drop license-verification
+%   coverage but also does not break the default cloud-api run.
 
     methods (TestClassSetup)
         function checkCredentials(testCase)
@@ -32,11 +34,13 @@ classdef HelloMatlabTest < matlab.unittest.TestCase
         function testHelloMatlabFlow(testCase)
             narrative = "Begin HelloMatlabTest: testHelloMatlabFlow";
 
-            if isempty(getenv("NDI_CLOUD_RUN_HELLO_MATLAB"))
+            runFlag = string(getenv("NDI_CLOUD_RUN_HELLO_MATLAB"));
+            shouldRun = strcmpi(runFlag, "true") || runFlag == "1";
+            if ~shouldRun
                 testCase.assumeFail(...
                     "Set NDI_CLOUD_RUN_HELLO_MATLAB=1 to run the hello-matlab-v1 " + ...
                     "end-to-end test (it launches a real EC2 instance and requires " + ...
-                    "a registered MATLAB BYOL license).");
+                    "a registered MATLAB BYOL license). Current value: """ + runFlag + """.");
             end
 
             % --- 1. Sanity-check that a license is registered before we


### PR DESCRIPTION
## Summary
Enhanced the `HelloMatlabTest` to properly validate the `NDI_CLOUD_RUN_HELLO_MATLAB` environment variable, accepting explicit truthy values ("1" or "true", case-insensitive) while treating any other value as opt-out.

## Changes
- **Updated documentation**: Clarified in comments that the test only runs when the environment variable is set to a truthy value, and that any other value (including "0", "false", or unset) triggers a skip via `assumeFail`
- **Improved variable validation logic**: Changed from checking if the environment variable is empty to explicitly parsing it and checking for truthy values ("true" or "1", case-insensitive)
- **Enhanced error messaging**: Updated the `assumeFail` message to include the current value of the environment variable, making it easier to debug configuration issues

## Implementation Details
The test now:
1. Retrieves the environment variable and converts it to a string
2. Checks if it matches "true" (case-insensitive) or equals "1"
3. Only proceeds with the test if one of these conditions is met
4. Provides the actual environment variable value in the skip message for better diagnostics

This approach is more explicit and user-friendly than the previous empty-check, reducing ambiguity about what values enable or disable the test.

https://claude.ai/code/session_01HC85iwNNdRH6hkdiLpLtbq