### PR TITLE
Filter out macOS AppleDouble shadow files from epochprobemap matching

### DIFF
--- a/src/ndi/+ndi/+file/navigator.m
+++ b/src/ndi/+ndi/+file/navigator.m
@@ -328,13 +328,18 @@ classdef navigator < ndi.ido & ndi.epoch.epochset.param & ndi.documentservice & 
                     return;
                 end
                 fn = {};
+                isshadow = false(1,numel(epochfiles));
                 for i=1:length(epochfiles)
                     [pa,name,ext] = fileparts(epochfiles{i});
                     fn{i} = [name ext];
+                    % some file systems (e.g., macOS) create AppleDouble shadow
+                    % files that begin with '._'; never treat these as epochprobemap files
+                    isshadow(i) = startsWith(fn{i},'._');
                 end
                 for i=1:numel(ndi_filenavigator_obj.epochprobemap_fileparameters.filematch)
                     tf = strcmp_substitution(ndi_filenavigator_obj.epochprobemap_fileparameters.filematch{i}, fn);
                     indexes = find(tf);
+                    indexes = indexes(~isshadow(indexes)); % drop any matched shadow files
                     if numel(indexes)>0
                         ecfname = epochfiles{indexes(1)};
                         break;


### PR DESCRIPTION
## Summary
This change prevents macOS AppleDouble shadow files (those prefixed with `._`) from being incorrectly matched as epochprobemap files during file navigation.

## Key Changes
- Added detection logic to identify shadow files that begin with `._` prefix, which are automatically created by macOS file systems
- Filter out any matched shadow files from the epochprobemap file selection process to ensure only legitimate epochprobemap files are used

## Implementation Details
- A boolean array `isshadow` is created to track which files are shadow files
- Each filename is checked using `startsWith(fn{i},'._')` to identify shadow files
- When epochprobemap files are matched, any shadow files in the matched results are explicitly excluded using `indexes = indexes(~isshadow(indexes))`
- This ensures the file navigator selects the correct epochprobemap file even when shadow files are present in the directory

https://claude.ai/code/session_01Ds4bHxhNCcRY6v3qDfbDPd