### PR TITLE
Audit remediation (2026-06): rebuild the Java validator JAR off the security-pinned pom

### DIFF
--- a/src/ndi/java/ndi-validator-java/source-code/.gitignore
+++ b/src/ndi/java/ndi-validator-java/source-code/.gitignore
@@ -1,0 +1,2 @@
+target/
+dependency-reduced-pom.xml

--- a/src/ndi/java/ndi-validator-java/source-code/src/test/java/com/ndi/EnumFormatValidatorTest.java
+++ b/src/ndi/java/ndi-validator-java/source-code/src/test/java/com/ndi/EnumFormatValidatorTest.java
@@ -338,9 +338,9 @@ class EnumFormatValidatorTest {
         assertEquals(test.validate("entry12"), Optional.of("Entered: " + "entry12" + ". Expected: any one of " + "[entry5]"));
         assertEquals(test.validate("entry11"), Optional.of("Entered: " + "entry11" + ". Expected: any one of " + "[entry6]"));
 
-        //test = test.unload();
+        test = (EnumFormatValidator) test.unload();
         assertNull(test.getTable());
-        //test = test.loadTable();
+        test = (EnumFormatValidator) test.loadTable();
         assertNotNull(test.getTable());
         assertEquals(test.validate("entry1"), Optional.empty());
         assertEquals(test.validate("entry5"), Optional.empty());


### PR DESCRIPTION
Part of the 2026-06 cross-repo NDI ecosystem audit remediation (the NDI-matlab slice; M0–M6 landed previously). This is the remaining substantive gate.

## What
- Rebuilds the bundled Java validator **JAR** off the **security-pinned `pom.xml`** (the dependency pins from the M2 security pass), so the shipped artifact matches the audited/pinned build inputs.
- Fixes a **pre-existing broken test** surfaced by the rebuild.

## Why
The JAR in the tree predated the security pins, so the shipped validator didn't correspond to the audited dependency set. This makes the artifact reproducible from the pinned pom.

## Notes
- Build/artifact + test only — no runtime API change.
- Opened for your review; we are not self-merging.