### PR TITLE
Expand pyraview probe support beyond n-trode probes

### DIFF
--- a/src/ndi/+ndi/+gui/+app/pyraview.m
+++ b/src/ndi/+ndi/+gui/+app/pyraview.m
@@ -88,10 +88,11 @@ classdef pyraview < ndi.gui.app.sessionApp
 
             % Show every multifunction-DAQ timeseries probe (n-trode, patch,
             % sharp, ecg, eeg, ppg, accelerometer, etc.), i.e. anything that
-            % is an ndi.probe.timeseries.mfdaq. A single class-name argument to
-            % getprobes performs an isa() match, which excludes stimulator and
-            % image probes (siblings of mfdaq under ndi.probe.timeseries).
-            probes = session.getprobes('ndi.probe.timeseries.mfdaq');
+            % is an ndi.probe.timeseries.mfdaq. Stimulator and image probes are
+            % siblings of mfdaq under ndi.probe.timeseries and are excluded by
+            % the isa() test.
+            allprobes = session.getprobes();
+            probes = allprobes(cellfun(@(p) isa(p, 'ndi.probe.timeseries.mfdaq'), allprobes));
             probe_strings = {};
             for i = 1:numel(probes)
                 probe_strings{end+1} = probes{i}.elementstring(); %#ok<AGROW>

--- a/src/ndi/+ndi/+gui/+app/pyraview.m
+++ b/src/ndi/+ndi/+gui/+app/pyraview.m
@@ -4,7 +4,7 @@ classdef pyraview < ndi.gui.app.sessionApp
 %   OBJ = ndi.gui.app.pyraview(SESSION)
 %
 %   Opens a signal viewer for the ndi.session SESSION. The window shows the
-%   continuous data for a chosen n-trode probe, epoch and filter band, with
+%   continuous data for a chosen probe, epoch and filter band, with
 %   pan/zoom scrollbars and an optional spiking-units panel that overlays
 %   spike ticks on the traces and shows unit waveforms on the side.
 %
@@ -23,7 +23,7 @@ classdef pyraview < ndi.gui.app.sessionApp
         fig                        % the figure
         mainAxes                   % main trace axes
         spikingAxes                % spiking waveform axes
-        probes = {}                % cell array of n-trode probes
+        probes = {}                % cell array of ndi.probe.timeseries.mfdaq probes
 
         current_doc = []           % pyraview document for the current view
         epoch_t0 = 0               % epoch start time (s)
@@ -86,7 +86,12 @@ classdef pyraview < ndi.gui.app.sessionApp
                 'HorizontalAlignment', 'left', 'Tag', 'ProbeText', ...
                 'FontWeight', 'bold', 'FontSize', 14);
 
-            probes = session.getprobes('type', 'n-trode');
+            % Show every multifunction-DAQ timeseries probe (n-trode, patch,
+            % sharp, ecg, eeg, ppg, accelerometer, etc.), i.e. anything that
+            % is an ndi.probe.timeseries.mfdaq. A single class-name argument to
+            % getprobes performs an isa() match, which excludes stimulator and
+            % image probes (siblings of mfdaq under ndi.probe.timeseries).
+            probes = session.getprobes('ndi.probe.timeseries.mfdaq');
             probe_strings = {};
             for i = 1:numel(probes)
                 probe_strings{end+1} = probes{i}.elementstring(); %#ok<AGROW>

--- a/src/ndi/+ndi/+gui/+app/pyraview.m
+++ b/src/ndi/+ndi/+gui/+app/pyraview.m
@@ -1172,11 +1172,11 @@ classdef pyraview < ndi.gui.app.sessionApp
             current_x = margin + 50 + 200 + margin;
             et = findobj(fig, 'Tag', 'EpochText');
             em = findobj(fig, 'Tag', 'EpochMenu');
-            set(et, 'Position', [current_x, top_y, 60, control_height]);
-            set(em, 'Position', [current_x + 60, top_y, 200, control_height]);
+            set(et, 'Position', [current_x, top_y, 80, control_height]);
+            set(em, 'Position', [current_x + 80, top_y, 200, control_height]);
 
             % Row 1 continued: Band | Spacing
-            current_x = current_x + 60 + 200 + margin;
+            current_x = current_x + 80 + 200 + margin;
             bt = findobj(fig, 'Tag', 'BandText');
             bm = findobj(fig, 'Tag', 'BandMenu');
             set(bt, 'Position', [current_x, top_y, 40, control_height]);
@@ -1185,16 +1185,16 @@ classdef pyraview < ndi.gui.app.sessionApp
             current_x = current_x + 40 + 80 + margin;
             st = findobj(fig, 'Tag', 'SpacingText');
             se = findobj(fig, 'Tag', 'SpacingEdit');
-            set(st, 'Position', [current_x, top_y, 60, control_height]);
-            set(se, 'Position', [current_x + 60, top_y, 50, control_height]);
+            set(st, 'Position', [current_x, top_y, 75, control_height]);
+            set(se, 'Position', [current_x + 75, top_y, 50, control_height]);
 
-            current_x = current_x + 60 + 50 + margin;
+            current_x = current_x + 75 + 50 + margin;
             mt = findobj(fig, 'Tag', 'MappingText');
             mm = findobj(fig, 'Tag', 'MappingMenu');
-            set(mt, 'Position', [current_x, top_y, 60, control_height]);
-            set(mm, 'Position', [current_x + 60, top_y, 100, control_height]);
+            set(mt, 'Position', [current_x, top_y, 75, control_height]);
+            set(mm, 'Position', [current_x + 75, top_y, 100, control_height]);
 
-            current_x = current_x + 60 + 100 + margin;
+            current_x = current_x + 75 + 100 + margin;
             sc = findobj(fig, 'Tag', 'SpikingCheckbox');
             set(sc, 'Position', [current_x, top_y, 200, control_height]);
 


### PR DESCRIPTION
## Summary
Updated the pyraview signal viewer to support all multifunction-DAQ timeseries probes (n-trode, patch, sharp, ecg, eeg, ppg, accelerometer, etc.) instead of being limited to n-trode probes only.

## Key Changes
- Modified probe filtering logic to use `isa()` check for `ndi.probe.timeseries.mfdaq` class instead of hardcoded 'n-trode' type string
- Updated documentation comments to reflect the broader probe support
- Added detailed inline comments explaining the probe selection criteria and why stimulator and image probes are excluded

## Implementation Details
- Changed from `session.getprobes('type', 'n-trode')` to filtering all probes with `cellfun(@(p) isa(p, 'ndi.probe.timeseries.mfdaq'), allprobes)`
- This approach is more maintainable and extensible, as it relies on class hierarchy rather than string matching
- The implementation correctly excludes sibling probe types (stimulator, image) that are under `ndi.probe.timeseries` but not `mfdaq`

https://claude.ai/code/session_01CTmPFQHhg8w6JEFz939koV