### PR TITLE
Remove redundant MATLAB path restoration steps from CI workflows

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -93,14 +93,6 @@ jobs:
             addpath(genpath( "tools" ));
             testToolboxNoCloud()
 
-      - name: Restore MATLAB Path
-        uses: matlab-actions/run-command@37b454c384483087929a3d652be474ba585a9659 # v2
-        if: always()
-        with:
-          command: |
-            restoredefaultpath()
-            savepath()
-
       - name: Commit SVG badges if updated
         if: always() && ( github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository )
         uses: ehennestad/matbox-actions/push-badges@8fe220fbaec9e119ec5081eb917c8e016e275f1e # v1

--- a/.github/workflows/test-cloud-api.yml
+++ b/.github/workflows/test-cloud-api.yml
@@ -64,11 +64,3 @@ jobs:
         uses: mikepenz/action-junit-report@db71d41eb79864e25ab0337e395c352e84523afe # v4
         with:
           report_paths: 'docs/reports/test-results.xml'
-
-      - name: Restore MATLAB Path
-        uses: matlab-actions/run-command@37b454c384483087929a3d652be474ba585a9659 # v2
-        if: always()
-        with:
-          command: |
-            restoredefaultpath()
-            savepath()

--- a/.github/workflows/test-cloud-prod.yml
+++ b/.github/workflows/test-cloud-prod.yml
@@ -72,11 +72,3 @@ jobs:
         with:
           report_paths: 'docs/reports/test-results.xml'
           check_name: 'Cloud CI ${{ matrix.part }} test results'
-
-      - name: Restore MATLAB Path
-        uses: matlab-actions/run-command@37b454c384483087929a3d652be474ba585a9659 # v2
-        if: always()
-        with:
-          command: |
-            restoredefaultpath()
-            savepath()

--- a/.github/workflows/test-symmetry.yml
+++ b/.github/workflows/test-symmetry.yml
@@ -95,11 +95,3 @@ jobs:
             disp(table(results));
 
             assert(all(~[results.Failed]), "Some symmetry tests failed")
-
-      - name: Restore MATLAB Path
-        uses: matlab-actions/run-command@37b454c384483087929a3d652be474ba585a9659 # v2
-        if: always()
-        with:
-          command: |
-            restoredefaultpath()
-            savepath()


### PR DESCRIPTION
## Summary
Removed redundant "Restore MATLAB Path" steps from four CI workflow files. These steps were calling `restoredefaultpath()` and `savepath()` after test execution, which appears to be unnecessary cleanup operations.

## Changes Made
- Removed the "Restore MATLAB Path" step from `run-tests.yml`
- Removed the "Restore MATLAB Path" step from `test-cloud-api.yml`
- Removed the "Restore MATLAB Path" step from `test-cloud-prod.yml`
- Removed the "Restore MATLAB Path" step from `test-symmetry.yml`

## Details
Each workflow had an identical cleanup step that executed `restoredefaultpath()` and `savepath()` commands via the matlab-actions/run-command action. These steps were configured to run `if: always()`, ensuring they executed regardless of test success or failure. The removal of these redundant steps simplifies the workflows without impacting functionality, as MATLAB path state is typically isolated per workflow execution.

https://claude.ai/code/session_01FemQpmYbEZpYQDgmW6JHzZ