### PR TITLE
Add organization name and upload permission fields to user API

### DIFF
--- a/src/ndi/+ndi/+cloud/+api/+implementation/+users/Me.m
+++ b/src/ndi/+ndi/+cloud/+api/+implementation/+users/Me.m
@@ -39,48 +39,17 @@ classdef Me < ndi.cloud.api.call
                 end
 
                 % Process the organizations list into parallel convenience
-                % arrays. Each organization is an OrganizationListItem with
-                % fields 'id', 'name' and 'canUploadDataset' (see the NDI Cloud
-                % API definition of UserWithOrganizations). The raw
-                % 'organizations' field is left untouched for callers that want
-                % the full structs.
-                asChar = @(v) char(string(v));
-
+                % arrays. The raw 'organizations' field is left untouched for
+                % callers that want the full structs.
                 answer.organizationID = {};
                 answer.organizationName = {};
                 answer.organizationCanUploadDataset = {};
 
                 if isfield(answer, 'organizations')
-                    orgs = answer.organizations;
-
-                    % Normalize to a cell array of scalar structs so that a
-                    % struct array (typical) and a cell array of structs (as
-                    % jsondecode sometimes returns) are handled identically.
-                    orgList = {};
-                    if isstruct(orgs)
-                        for i = 1:numel(orgs)
-                            orgList{end+1} = orgs(i); %#ok<AGROW>
-                        end
-                    elseif iscell(orgs)
-                        orgList = orgs;
-                    end
-
-                    for i = 1:numel(orgList)
-                        org = orgList{i};
-                        if ~isstruct(org)
-                            continue;
-                        end
-                        if isfield(org, 'id')
-                            answer.organizationID{end+1} = asChar(org.id);
-                        end
-                        if isfield(org, 'name')
-                            answer.organizationName{end+1} = asChar(org.name);
-                        end
-                        if isfield(org, 'canUploadDataset')
-                            answer.organizationCanUploadDataset{end+1} = ...
-                                logical(org.canUploadDataset);
-                        end
-                    end
+                    [answer.organizationID, answer.organizationName, ...
+                        answer.organizationCanUploadDataset] = ...
+                        ndi.cloud.api.implementation.users.Me.parseOrganizations(...
+                        answer.organizations);
                 end
             else
                 if isprop(apiResponse.Body, 'Data')
@@ -89,6 +58,58 @@ classdef Me < ndi.cloud.api.call
                      answer = apiResponse.Body.Payload;
                 else
                     answer = apiResponse.Body;
+                end
+            end
+        end
+    end
+
+    methods (Static)
+        function [orgID, orgName, orgCanUpload] = parseOrganizations(orgs)
+            %PARSEORGANIZATIONS Extract parallel id/name/upload arrays from an
+            %   organizations list.
+            %
+            %   [ORGID, ORGNAME, ORGCANUPLOAD] = parseOrganizations(ORGS)
+            %
+            %   ORGS is the 'organizations' field returned by the NDI Cloud
+            %   /users/me endpoint: an array of OrganizationListItem structs,
+            %   each with fields 'id', 'name' and 'canUploadDataset'. It may be
+            %   a struct array (typical) or a cell array of scalar structs (as
+            %   jsondecode sometimes returns); both are handled identically.
+            %
+            %   Returns three cell arrays, parallel to one another:
+            %       ORGID        - organization IDs (char)
+            %       ORGNAME      - organization names (char)
+            %       ORGCANUPLOAD - upload permission per organization (logical)
+
+            asChar = @(v) char(string(v));
+
+            orgID = {};
+            orgName = {};
+            orgCanUpload = {};
+
+            % Normalize to a cell array of scalar structs.
+            orgList = {};
+            if isstruct(orgs)
+                for i = 1:numel(orgs)
+                    orgList{end+1} = orgs(i); %#ok<AGROW>
+                end
+            elseif iscell(orgs)
+                orgList = orgs;
+            end
+
+            for i = 1:numel(orgList)
+                org = orgList{i};
+                if ~isstruct(org)
+                    continue;
+                end
+                if isfield(org, 'id')
+                    orgID{end+1} = asChar(org.id); %#ok<AGROW>
+                end
+                if isfield(org, 'name')
+                    orgName{end+1} = asChar(org.name); %#ok<AGROW>
+                end
+                if isfield(org, 'canUploadDataset')
+                    orgCanUpload{end+1} = logical(org.canUploadDataset); %#ok<AGROW>
                 end
             end
         end

--- a/src/ndi/+ndi/+cloud/+api/+implementation/+users/Me.m
+++ b/src/ndi/+ndi/+cloud/+api/+implementation/+users/Me.m
@@ -38,39 +38,49 @@ classdef Me < ndi.cloud.api.call
                     answer.id = char(answer.id);
                 end
 
-                % Process organizations to create organizationID cell array
-                if isfield(answer, 'organizations')
-                    % Initialize as empty cell array
-                    answer.organizationID = {};
+                % Process the organizations list into parallel convenience
+                % arrays. Each organization is an OrganizationListItem with
+                % fields 'id', 'name' and 'canUploadDataset' (see the NDI Cloud
+                % API definition of UserWithOrganizations). The raw
+                % 'organizations' field is left untouched for callers that want
+                % the full structs.
+                asChar = @(v) char(string(v));
 
+                answer.organizationID = {};
+                answer.organizationName = {};
+                answer.organizationCanUploadDataset = {};
+
+                if isfield(answer, 'organizations')
                     orgs = answer.organizations;
+
+                    % Normalize to a cell array of scalar structs so that a
+                    % struct array (typical) and a cell array of structs (as
+                    % jsondecode sometimes returns) are handled identically.
+                    orgList = {};
                     if isstruct(orgs)
-                        % If it's a struct array
-                        if isfield(orgs, 'id')
-                            % Extract IDs
-                            for i = 1:numel(orgs)
-                                val = orgs(i).id;
-                                if isstring(val)
-                                    val = char(val);
-                                end
-                                answer.organizationID{end+1} = val;
-                            end
+                        for i = 1:numel(orgs)
+                            orgList{end+1} = orgs(i); %#ok<AGROW>
                         end
                     elseif iscell(orgs)
-                        % If it's a cell array of structs (e.g. from jsondecode sometimes)
-                        for i = 1:numel(orgs)
-                            if isfield(orgs{i}, 'id')
-                                val = orgs{i}.id;
-                                if isstring(val)
-                                    val = char(val);
-                                end
-                                answer.organizationID{end+1} = val;
-                            end
+                        orgList = orgs;
+                    end
+
+                    for i = 1:numel(orgList)
+                        org = orgList{i};
+                        if ~isstruct(org)
+                            continue;
+                        end
+                        if isfield(org, 'id')
+                            answer.organizationID{end+1} = asChar(org.id);
+                        end
+                        if isfield(org, 'name')
+                            answer.organizationName{end+1} = asChar(org.name);
+                        end
+                        if isfield(org, 'canUploadDataset')
+                            answer.organizationCanUploadDataset{end+1} = ...
+                                logical(org.canUploadDataset);
                         end
                     end
-                else
-                    % If no organizations field, ensure organizationID exists as empty cell
-                    answer.organizationID = {};
                 end
             else
                 if isprop(apiResponse.Body, 'Data')

--- a/src/ndi/+ndi/+cloud/+api/+users/me.m
+++ b/src/ndi/+ndi/+cloud/+api/+users/me.m
@@ -3,16 +3,45 @@ function [b, answer, apiResponse, apiURL] = me()
 %
 %   [B, ANSWER, APIRESPONSE, APIURL] = ndi.cloud.api.users.me()
 %
-%   Retrieves the public profile information for the current user.
+%   Retrieves the public profile information for the current user, including
+%   the organizations that the user belongs to.
 %
 %   Outputs:
 %       b            - True if the call succeeded, false otherwise.
-%       answer       - A struct with user information on success, or an error struct on failure.
+%       answer       - A struct with user information on success, or an error
+%                      struct on failure. On success it contains the fields
+%                      returned by the NDI Cloud API for the current user:
+%                        id                     - user ID (char)
+%                        name                   - user's name
+%                        email                  - user's email
+%                        isValidated            - whether the account is validated
+%                        isAdmin                - whether the user is an admin
+%                        bookmarkedDatasetIds   - IDs of bookmarked datasets
+%                        organizations          - array of the raw organization
+%                                                 structs (each with fields
+%                                                 'id', 'name' and
+%                                                 'canUploadDataset')
+%                      plus the following convenience fields derived from
+%                      'organizations':
+%                        organizationID              - cell array of organization
+%                                                      IDs (char) the user belongs to
+%                        organizationName            - cell array of organization
+%                                                      names (char), parallel to
+%                                                      organizationID
+%                        organizationCanUploadDataset - cell array of logicals,
+%                                                      parallel to organizationID,
+%                                                      indicating upload permission
 %       apiResponse  - The full matlab.net.http.ResponseMessage object.
 %       apiURL       - The URL that was called.
 %
 %   Example:
 %       [success, userInfo] = ndi.cloud.api.users.me();
+%       if success
+%           for i = 1:numel(userInfo.organizationID)
+%               fprintf('%s (%s)\n', userInfo.organizationName{i}, ...
+%                   userInfo.organizationID{i});
+%           end
+%       end
 %
 %   See also: ndi.cloud.api.implementation.users.Me
 

--- a/tests/+ndi/+unittest/+cloud/UserTest.m
+++ b/tests/+ndi/+unittest/+cloud/UserTest.m
@@ -56,6 +56,27 @@ classdef UserTest < matlab.unittest.TestCase
                     end
                 end
 
+                % Verify organizationName is a cell array of chars, parallel
+                % to organizationID
+                testCase.verifyTrue(isfield(answer_me, 'organizationName'), me_message);
+                if isfield(answer_me, 'organizationName')
+                    testCase.verifyClass(answer_me.organizationName, 'cell', me_message);
+                    testCase.verifyEqual(numel(answer_me.organizationName), ...
+                        numel(answer_me.organizationID), me_message);
+                    for i = 1:numel(answer_me.organizationName)
+                        testCase.verifyClass(answer_me.organizationName{i}, 'char', me_message);
+                    end
+                end
+
+                % Verify organizationCanUploadDataset is a cell array parallel
+                % to organizationID
+                testCase.verifyTrue(isfield(answer_me, 'organizationCanUploadDataset'), me_message);
+                if isfield(answer_me, 'organizationCanUploadDataset')
+                    testCase.verifyClass(answer_me.organizationCanUploadDataset, 'cell', me_message);
+                    testCase.verifyEqual(numel(answer_me.organizationCanUploadDataset), ...
+                        numel(answer_me.organizationID), me_message);
+                end
+
                 % Verify other fields exist as per new spec
                  testCase.verifyTrue(isfield(answer_me, 'email'), me_message);
                  testCase.verifyTrue(isfield(answer_me, 'name'), me_message);

--- a/tests/+ndi/+unittest/+cloud/UserTest.m
+++ b/tests/+ndi/+unittest/+cloud/UserTest.m
@@ -85,5 +85,53 @@ classdef UserTest < matlab.unittest.TestCase
 
             narrative(end+1) = "UserTest: testMe complete.";
         end
+
+        function testParseOrganizationsStructArray(testCase)
+            % Offline test of the organization-parsing helper used by the
+            % me() endpoint. Uses a struct array, the typical shape returned
+            % by the API. Requires no network access or credentials.
+            orgs = struct( ...
+                'id', {'org-1', 'org-2'}, ...
+                'name', {'Alpha Lab', 'Beta Institute'}, ...
+                'canUploadDataset', {true, false});
+
+            [orgID, orgName, orgCanUpload] = ...
+                ndi.cloud.api.implementation.users.Me.parseOrganizations(orgs);
+
+            testCase.verifyEqual(orgID, {'org-1', 'org-2'});
+            testCase.verifyEqual(orgName, {'Alpha Lab', 'Beta Institute'});
+            testCase.verifyEqual(orgCanUpload, {true, false});
+            % IDs and names must be char, not string
+            testCase.verifyClass(orgID{1}, 'char');
+            testCase.verifyClass(orgName{1}, 'char');
+        end
+
+        function testParseOrganizationsCellArray(testCase)
+            % Offline test of the organization-parsing helper with a cell
+            % array of scalar structs (the shape jsondecode sometimes returns)
+            % and string-typed values that must be coerced to char.
+            orgs = {struct('id', "org-9", 'name', "Gamma Center", ...
+                'canUploadDataset', true)};
+
+            [orgID, orgName, orgCanUpload] = ...
+                ndi.cloud.api.implementation.users.Me.parseOrganizations(orgs);
+
+            testCase.verifyEqual(orgID, {'org-9'});
+            testCase.verifyEqual(orgName, {'Gamma Center'});
+            testCase.verifyEqual(orgCanUpload, {true});
+            testCase.verifyClass(orgID{1}, 'char');
+            testCase.verifyClass(orgName{1}, 'char');
+        end
+
+        function testParseOrganizationsEmpty(testCase)
+            % Offline test that an empty organizations list yields empty
+            % parallel cell arrays.
+            [orgID, orgName, orgCanUpload] = ...
+                ndi.cloud.api.implementation.users.Me.parseOrganizations(struct([]));
+
+            testCase.verifyEqual(orgID, {});
+            testCase.verifyEqual(orgName, {});
+            testCase.verifyEqual(orgCanUpload, {});
+        end
     end
 end


### PR DESCRIPTION
## Summary
Enhanced the `ndi.cloud.api.users.me()` endpoint to extract and expose additional organization metadata alongside the existing organization IDs. The API now provides parallel convenience arrays for organization names and upload permissions, making it easier for callers to work with user organization data.

## Key Changes
- **Extended organization data extraction**: In addition to `organizationID`, the implementation now extracts `organizationName` and `organizationCanUploadDataset` from the organizations list returned by the NDI Cloud API
- **Improved data normalization**: Refactored organization processing to handle both struct arrays and cell arrays of structs uniformly, with better separation of concerns
- **Added helper function**: Introduced `asChar` lambda function to consistently convert values to char type, reducing code duplication
- **Enhanced documentation**: Updated the `me.m` function documentation to describe all returned fields, including the new convenience arrays and the raw organizations field
- **Added test coverage**: Extended `UserTest.m` to verify that `organizationName` and `organizationCanUploadDataset` are properly populated as cell arrays parallel to `organizationID`

## Implementation Details
- The raw `organizations` field is preserved untouched for callers that need the full organization structs
- All three convenience arrays (`organizationID`, `organizationName`, `organizationCanUploadDataset`) are initialized as empty cell arrays and populated in parallel during iteration
- String-to-char conversion is applied consistently across all extracted fields
- The `canUploadDataset` field is explicitly converted to logical type for type safety

https://claude.ai/code/session_01EgX91zQsAe8Z2wMB8YcCHf