### PR TITLE
Fix vhajbpod_np epoch matching: one epoch per Epoch_Set, per-set NI-DAQ triggers

### DIFF
--- a/src/ndi/+ndi/+setup/+daq/+reader/+mfdaq/+stimulus/VHAudreyBPod.m
+++ b/src/ndi/+ndi/+setup/+daq/+reader/+mfdaq/+stimulus/VHAudreyBPod.m
@@ -17,6 +17,16 @@ classdef VHAudreyBPod < ndi.daq.reader.mfdaq
     %     'dev_local_time' as its epoch clock so events align with the
     %     SpikeGLX neuropixelsGLX data.
     %
+    %     A single NI-DAQ recording is shared by every Epoch_Set in the
+    %     *_g0 run and therefore records the trigger edges of all of the
+    %     run's stimulus sets. Each epoch corresponds to one Epoch_Set, so
+    %     the reader reads the whole edge train and returns only the
+    %     contiguous block belonging to that set (sets are ordered
+    %     chronologically and their stimulus counts concatenated). The total
+    %     number of NI-DAQ edges must equal the total number of stimuli
+    %     across the run's Epoch_Set logs (one trigger per stimulus); if it
+    %     does not, an error is raised rather than mis-assigning triggers.
+    %
     %   - Otherwise (as in the Intan-based vhtaste_bpod sessions), the
     %     HHMMSS StartTime / EndTime columns of the TSV log are used
     %     directly and the reader falls back to the default mfdaq epoch
@@ -84,14 +94,25 @@ classdef VHAudreyBPod < ndi.daq.reader.mfdaq
                 channeltype = repmat({channeltype}, numel(channel), 1);
             end
 
-            % Find and parse the TSV stimulus trigger log
+            % Find and parse this Epoch_Set's TSV stimulus trigger log
             tsvFile = ndi.setup.daq.reader.mfdaq.stimulus.VHAudreyBPod.findTsvFile(epochfiles);
             [stimid, tsv_start_sec, tsv_end_sec] = ...
                 ndi.setup.daq.reader.mfdaq.stimulus.VHAudreyBPod.parseAudreyBPodTsv(tsvFile);
 
             % Decide how to get the stimulus on / off times
             if ndi.setup.daq.reader.mfdaq.stimulus.VHAudreyBPod.hasNidqBin(epochfiles)
-                [stimontimes, stimofftimes] = obj.readNidqTriggers(epochfiles, t0, t1);
+                % A single SpikeGLX NI-DAQ recording holds the trigger edges
+                % for EVERY Epoch_Set in this *_g0 run, so read the whole edge
+                % train (from the start to the end of the recording) and hand
+                % this set only the contiguous slice that belongs to it. The
+                % number of NI-DAQ trigger edges must equal the total number of
+                % stimuli across all of the run's Epoch_Set logs (each stimulus
+                % is one trigger); sliceTriggersForSet enforces this with a
+                % loud error and does the per-set assignment.
+                [allon, alloff] = obj.readNidqTriggers(epochfiles, -Inf, Inf);
+                [stimontimes, stimofftimes] = ...
+                    ndi.setup.daq.reader.mfdaq.stimulus.VHAudreyBPod.sliceTriggersForSet(...
+                        epochfiles, tsvFile, allon, alloff);
             else
                 stimontimes  = tsv_start_sec;
                 stimofftimes = tsv_end_sec;
@@ -170,6 +191,129 @@ classdef VHAudreyBPod < ndi.daq.reader.mfdaq
                 end
             end
             error('No .tsv file found in epochfiles.');
+        end
+
+        function [stimontimes, stimofftimes] = sliceTriggersForSet(epochfiles, tsvFile, allon, alloff)
+            % SLICETRIGGERSFORSET - return the NI-DAQ trigger edges that belong to one Epoch_Set.
+            %
+            % [STIMONTIMES, STIMOFFTIMES] = SLICETRIGGERSFORSET(EPOCHFILES, TSVFILE, ALLON, ALLOFF)
+            %
+            % A single SpikeGLX NI-DAQ recording (shared at the top of the
+            % *_g0 run directory) records the trigger edges for every
+            % Epoch_Set in the run. ALLON / ALLOFF are the full rising /
+            % falling edge times of NI-DAQ digital input 1 for that whole
+            % recording. This function finds every Epoch_Set stimulus log
+            % under the run directory, orders them chronologically (by the
+            % first stimulus start time in each log), and returns the
+            % contiguous block of edges that corresponds to the set whose log
+            % is TSVFILE.
+            %
+            % Each stimulus must correspond to exactly one trigger edge, so
+            % the total number of rising (and falling) edges must equal the
+            % total number of stimuli across all of the run's logs. If it does
+            % not, a loud error is raised rather than guessing an assignment.
+
+            import ndi.setup.daq.reader.mfdaq.stimulus.VHAudreyBPod
+
+            g0dir = VHAudreyBPod.runDirOf(epochfiles);
+            tsvs  = VHAudreyBPod.findAllTsvsUnder(g0dir);
+            if isempty(tsvs)
+                error(['VHAudreyBPod: no stimulus-trigger .tsv logs were found under ' g0dir '.']);
+            end
+
+            % Count stimuli and earliest start time (for chronological order)
+            % for each Epoch_Set log.
+            counts = zeros(numel(tsvs),1);
+            starts = zeros(numel(tsvs),1);
+            for i = 1:numel(tsvs)
+                [~, s_start] = VHAudreyBPod.parseAudreyBPodTsv(tsvs{i});
+                counts(i) = numel(s_start);
+                if isempty(s_start)
+                    starts(i) = Inf;
+                else
+                    starts(i) = min(s_start);
+                end
+            end
+            [~, ord] = sort(starts);
+            tsvs   = tsvs(ord);
+            counts = counts(ord);
+
+            total = sum(counts);
+            non   = numel(allon);
+            noff  = numel(alloff);
+            if non ~= total || noff ~= total
+                error(['VHAudreyBPod: trigger-count mismatch in ' g0dir '. ' ...
+                    'NI-DAQ digital input 1 has ' int2str(non) ' rising and ' ...
+                    int2str(noff) ' falling edges, but the ' int2str(numel(counts)) ...
+                    ' Epoch_Set stimulus log(s) list ' int2str(total) ' stimuli in total. ' ...
+                    'Each stimulus must correspond to exactly one NI-DAQ trigger; ' ...
+                    'check for missing/extra triggers or an incomplete stimulus log.']);
+            end
+
+            idx = VHAudreyBPod.matchTsvIndex(tsvs, tsvFile);
+            if isempty(idx)
+                error(['VHAudreyBPod: could not locate stimulus log ' tsvFile ...
+                    ' among the Epoch_Set logs of ' g0dir '.']);
+            end
+
+            offset = sum(counts(1:idx-1));
+            n      = counts(idx);
+            stimontimes  = allon(offset+1  : offset+n);
+            stimofftimes = alloff(offset+1 : offset+n);
+        end
+
+        function g0dir = runDirOf(epochfiles)
+            % RUNDIROF - the *_g0 SpikeGLX run directory, taken as the folder
+            % that holds the shared .nidq.bin file.
+            g0dir = '';
+            for i = 1:numel(epochfiles)
+                if endsWith(lower(epochfiles{i}), '.nidq.bin')
+                    g0dir = fileparts(epochfiles{i});
+                    return;
+                end
+            end
+            error('VHAudreyBPod: no .nidq.bin file in epoch; cannot locate the SpikeGLX run directory.');
+        end
+
+        function tsvs = findAllTsvsUnder(rootdir)
+            % FINDALLTSVSUNDER - full paths of every non-hidden
+            % *_stimulus_triggers_log.tsv file at or below ROOTDIR (the same
+            % files the vhlab_np_epochdir navigator groups into epochs).
+            tsvs = {};
+            if ~isfolder(rootdir)
+                return;
+            end
+            L = dir(fullfile(rootdir, '**', '*_stimulus_triggers_log.tsv'));
+            for i = 1:numel(L)
+                if L(i).isdir || L(i).name(1) == '.'
+                    continue;
+                end
+                tsvs{end+1,1} = fullfile(L(i).folder, L(i).name); %#ok<AGROW>
+            end
+        end
+
+        function idx = matchTsvIndex(tsvs, tsvFile)
+            % MATCHTSVINDEX - index of TSVFILE within the cell array TSVS.
+            % Matches on the full path first; if that fails (e.g. the paths
+            % were formed differently), falls back to a unique basename match.
+            idx = find(strcmp(tsvs, tsvFile), 1);
+            if ~isempty(idx)
+                return;
+            end
+            [~, nm, ex] = fileparts(tsvFile);
+            base = [nm ex];
+            hits = [];
+            for i = 1:numel(tsvs)
+                [~, nmi, exi] = fileparts(tsvs{i});
+                if strcmp([nmi exi], base)
+                    hits(end+1) = i; %#ok<AGROW>
+                end
+            end
+            if isscalar(hits)
+                idx = hits(1);
+            else
+                idx = [];
+            end
         end
 
         function [stimid, start_seconds, end_seconds] = parseAudreyBPodTsv(tsvFile)

--- a/src/ndi/+ndi/+setup/+file/+navigator/vhlab_np_epochdir.m
+++ b/src/ndi/+ndi/+setup/+file/+navigator/vhlab_np_epochdir.m
@@ -1,21 +1,28 @@
 classdef vhlab_np_epochdir < ndi.file.navigator.epochdir
     % NDI.SETUP.FILE.NAVIGATOR.VHLAB_NP_EPOCHDIR - epochdir file navigator
-    % that recurses into per-epoch subdirectories (e.g. Epoch_Set_1).
+    % for vhlab AJBPod-on-Neuropixels (SpikeGLX) sessions.
     %
-    % In vhlab SpikeGLX / Neuropixels GLX sessions, each epoch lives in an
-    % Epoch*_g0 subdirectory of the session directory (same as the standard
-    % epochdir layout), but the AJBPod stimulus log files (TSV + JSON) are
-    % placed one level deeper inside an Epoch_Set_X subdirectory of that
-    % epoch directory. The default ndi.file.navigator.epochdir only scans
-    % the immediate epoch directory (SearchDepth=1) and therefore misses
-    % those files.
+    % In these sessions each SpikeGLX run lives in an Epoch*_g0 subdirectory
+    % of the session directory. The shared SpikeGLX files (the .nidq.bin /
+    % .nidq.meta NI-DAQ recording and the .imec0.ap.meta probe file) sit at
+    % the top of that *_g0 directory, while the AJBPod stimulus log for each
+    % stimulus presentation is placed one level deeper, inside an Epoch_Set_X
+    % subdirectory, as a matched pair of files: a
+    % '*_stimulus_triggers_log.tsv' and a '*_summary_log.json'.
     %
-    % This navigator treats each first-level subdirectory of the session as
-    % one epoch and recursively collects every file (across all nested
-    % subdirectories) whose basename matches any of the configured
-    % FileParameters. All matching files are returned as a single epoch
-    % file group, so a VHAudreyBPodNP reader can combine the TSV / JSON
-    % with the SpikeGLX .nidq files from the parent epoch directory.
+    % A single *_g0 run may contain several stimulus presentations
+    % (Epoch_Set_1, Epoch_Set_2, ...). This navigator therefore treats each
+    % Epoch_Set_X as one epoch, pooling that set's .tsv / .json with the
+    % shared SpikeGLX files from the parent *_g0 directory so a VHAudreyBPod
+    % reader can combine the stimulus log with the NI-DAQ trigger recording.
+    %
+    % An Epoch_Set_X only becomes an epoch if the resulting file group
+    % satisfies EVERY configured FileParameter (an AND, matching the stock
+    % ndi.file.navigator.epochdir semantics): all of the SpikeGLX files AND
+    % the set's .tsv and .json must be present. A *_g0 directory that has
+    % only the SpikeGLX files but no stimulus log (a partial match) does not
+    % form an epoch -- previously such a directory formed a phantom epoch
+    % whose epoch probe map could not be resolved.
     %
 
     methods
@@ -26,10 +33,12 @@ classdef vhlab_np_epochdir < ndi.file.navigator.epochdir
         function id = epochid(obj, epoch_number, epochfiles)
             % EPOCHID - return the epoch identifier for an epoch.
             %
-            % For this navigator, each epoch corresponds to a first-level
-            % subdirectory of the session directory (e.g. Epoch1_g0). The
-            % returned id is the name of that subdirectory, regardless of
-            % how deeply nested the individual files in EPOCHFILES are.
+            % Each epoch corresponds to one Epoch_Set_X subdirectory of a
+            % first-level *_g0 directory of the session. The returned id is
+            % '<g0dir>_<Epoch_Set_dir>' so that multiple stimulus sets within
+            % one *_g0 run receive distinct epoch ids (and distinct hidden
+            % bookkeeping file names, which the base navigator derives from
+            % the first file of the group).
             %
             if nargin < 3
                 epochfiles = getepochfiles(obj, epoch_number);
@@ -39,29 +48,48 @@ classdef vhlab_np_epochdir < ndi.file.navigator.epochdir
                 return;
             end
             sess_path = obj.path();
-            % Use the first file to walk upward until its parent is the
-            % session directory; that parent is the epoch directory.
-            fpath = epochfiles{1};
-            id = '';
-            while true
-                [parent, name] = fileparts(fpath);
-                if isempty(parent) || strcmp(parent, fpath)
+
+            % The stimulus-trigger .tsv is what defines the set; use it to
+            % locate the Epoch_Set directory. Fall back to the first file.
+            setfile = '';
+            for i = 1:numel(epochfiles)
+                [~,~,ext] = fileparts(epochfiles{i});
+                if strcmpi(ext, '.tsv')
+                    setfile = epochfiles{i};
                     break;
                 end
-                if strcmp(parent, sess_path)
-                    id = name;
-                    return;
-                end
-                fpath = parent;
             end
-            % fallback to default behaviour
-            [pathdir, ~] = fileparts(epochfiles{1});
-            [~, id] = fileparts(pathdir);
+            if isempty(setfile)
+                setfile = epochfiles{1};
+            end
+
+            rel = setfile;
+            prefix = [sess_path filesep];
+            if startsWith(rel, prefix)
+                rel = rel(numel(prefix)+1:end);
+            end
+            parts = strsplit(rel, filesep);
+            if numel(parts) >= 2
+                % parts{1} is the *_g0 directory; parts{2} is the immediate
+                % Epoch_Set subdirectory that holds this set's files.
+                id = [parts{1} '_' parts{2}];
+            else
+                id = parts{1};
+            end
         end % epochid
 
         function [epochfiles_disk] = selectfilegroups_disk(obj)
-            % SELECTFILEGROUPS_DISK - find epoch file groups by walking
-            % each Epoch*_g0 directory recursively.
+            % SELECTFILEGROUPS_DISK - find epoch file groups on disk.
+            %
+            % One epoch is returned per Epoch_Set_X subdirectory of a
+            % first-level *_g0 directory of the session, provided the
+            % combined file group (the shared SpikeGLX files at the top of
+            % the *_g0 directory plus the files gathered under the set
+            % subdirectory) contains at least one file matching EVERY
+            % configured FileParameter. Sets that do not complete the match
+            % (for example a *_g0 directory with only SpikeGLX files and no
+            % stimulus log, or a non-set subdirectory such as *_imec0) are
+            % skipped.
 
             exp_path = obj.path();
             epochfiles_disk = {};
@@ -69,53 +97,103 @@ classdef vhlab_np_epochdir < ndi.file.navigator.epochdir
                 return;
             end
 
-            d = dir(exp_path);
-            d = d(~ismember({d.name}, {'.','..'}));
-            epoch_dirs = d([d.isdir]);
-
-            % Get the file-match patterns as a cell array of regexes
             filematch = obj.fileparameters.filematch;
             if ischar(filematch)
                 filematch = {filematch};
             end
+            regexes = ndi.setup.file.navigator.vhlab_np_epochdir.filematch2regex(filematch);
 
-            for k = 1:numel(epoch_dirs)
-                if epoch_dirs(k).name(1) == '.'
-                    continue;
-                end
-                epoch_path = fullfile(exp_path, epoch_dirs(k).name);
+            g0_dirs = ndi.setup.file.navigator.vhlab_np_epochdir.immediate_subdirs(exp_path);
 
-                matches = ndi.setup.file.navigator.vhlab_np_epochdir.gather_matching_files(epoch_path, filematch);
-                if ~isempty(matches)
-                    epochfiles_disk{end+1,1} = matches; %#ok<AGROW>
+            for k = 1:numel(g0_dirs)
+                g0_path = fullfile(exp_path, g0_dirs{k});
+
+                % Shared SpikeGLX files live directly in the *_g0 directory
+                % (do not descend into the Epoch_Set subdirectories here).
+                shared = ndi.setup.file.navigator.vhlab_np_epochdir.gather_matching_files(...
+                    g0_path, filematch, false);
+
+                % Each immediate subdirectory of the *_g0 directory is a
+                % candidate Epoch_Set; the .tsv / .json may be nested one
+                % level deeper, so gather them recursively.
+                set_dirs = ndi.setup.file.navigator.vhlab_np_epochdir.immediate_subdirs(g0_path);
+                for s = 1:numel(set_dirs)
+                    set_path = fullfile(g0_path, set_dirs{s});
+                    setfiles = ndi.setup.file.navigator.vhlab_np_epochdir.gather_matching_files(...
+                        set_path, filematch, true);
+                    if isempty(setfiles)
+                        continue;
+                    end
+
+                    % Put the stimulus-trigger .tsv first so it becomes
+                    % epochfiles{1}: the base navigator derives the per-epoch
+                    % epoch-id and hidden id/probe-map file names from the
+                    % first file, and this keeps them unique per Epoch_Set
+                    % rather than colliding on the shared SpikeGLX files.
+                    setfiles = ndi.setup.file.navigator.vhlab_np_epochdir.tsv_first(setfiles);
+
+                    group = [setfiles(:); shared(:)];
+                    if ndi.setup.file.navigator.vhlab_np_epochdir.covers_all(group, regexes)
+                        epochfiles_disk{end+1,1} = group; %#ok<AGROW>
+                    end
                 end
             end
         end % selectfilegroups_disk
     end % methods
 
     methods (Static, Access = private)
-        function files = gather_matching_files(rootdir, filematch)
-            % GATHER_MATCHING_FILES - recursively walk ROOTDIR and return a
-            % column cell array of full paths for every file whose basename
-            % matches any of the regexes in FILEMATCH. The same
-            % same-string-substitution symbol ('#') supported by
-            % vlt.file.findfilegroups is expanded to '.*' here so multiple
-            % loosely-coupled files can be collected together.
+        function names = immediate_subdirs(rootdir)
+            % IMMEDIATE_SUBDIRS - names of the immediate, non-hidden
+            % subdirectories of ROOTDIR, sorted for deterministic epoch
+            % ordering.
+            names = {};
+            if ~isfolder(rootdir)
+                return;
+            end
+            d = dir(rootdir);
+            for i = 1:numel(d)
+                if ~d(i).isdir
+                    continue;
+                end
+                if d(i).name(1) == '.'   % skips '.', '..', and dot-directories
+                    continue;
+                end
+                names{end+1,1} = d(i).name; %#ok<AGROW>
+            end
+            names = sort(names);
+        end % immediate_subdirs
+
+        function regexes = filematch2regex(filematch)
+            % FILEMATCH2REGEX - convert FileParameters patterns to plain
+            % regexes. The same-substring symbol ('#') supported by
+            % vlt.file.findfilegroups is expanded to '.*'; every other
+            % character is left as-is (the vhlab DAQ configuration already
+            % uses regular-expression patterns).
+            if ischar(filematch)
+                filematch = {filematch};
+            end
+            regexes = cell(size(filematch));
+            for i = 1:numel(filematch)
+                regexes{i} = strrep(filematch{i}, '#', '.*');
+            end
+        end % filematch2regex
+
+        function files = gather_matching_files(rootdir, filematch, recurse)
+            % GATHER_MATCHING_FILES - return a column cell array of full
+            % paths for every file under ROOTDIR whose basename matches any
+            % pattern in FILEMATCH. When RECURSE is true (default) the whole
+            % tree below ROOTDIR is walked; when false only the immediate
+            % files of ROOTDIR are considered. Hidden entries (names
+            % beginning with '.') are skipped, so OS/version-control
+            % directories such as '.git' are never traversed.
+            if nargin < 3
+                recurse = true;
+            end
             files = {};
             if ~isfolder(rootdir)
                 return;
             end
-
-            % Convert '#' placeholders into '.*' so each pattern is a
-            % plain regex. Uniqueness of the substitution string is not
-            % enforced here (this navigator groups by directory, not by
-            % substitution string).
-            regexes = cell(size(filematch));
-            for i = 1:numel(filematch)
-                pat = filematch{i};
-                pat = strrep(pat, '#', '.*');
-                regexes{i} = pat;
-            end
+            regexes = ndi.setup.file.navigator.vhlab_np_epochdir.filematch2regex(filematch);
 
             stack = {rootdir};
             while ~isempty(stack)
@@ -123,16 +201,14 @@ classdef vhlab_np_epochdir < ndi.file.navigator.epochdir
                 stack(end) = [];
                 entries = dir(cur);
                 for i = 1:numel(entries)
-                    % Skip hidden entries (names beginning with '.'); this
-                    % also covers '.' and '..' and must not traverse
-                    % directories such as '.git' or other dot-directories
-                    % created by the OS or version control.
                     if entries(i).name(1) == '.'
                         continue;
                     end
                     full = fullfile(cur, entries(i).name);
                     if entries(i).isdir
-                        stack{end+1} = full; %#ok<AGROW>
+                        if recurse
+                            stack{end+1} = full; %#ok<AGROW>
+                        end
                     else
                         for r = 1:numel(regexes)
                             if ~isempty(regexp(entries(i).name, regexes{r}, 'once'))
@@ -144,5 +220,42 @@ classdef vhlab_np_epochdir < ndi.file.navigator.epochdir
                 end
             end
         end % gather_matching_files
+
+        function files = tsv_first(files)
+            % TSV_FIRST - reorder FILES so that a '.tsv' file (the stimulus
+            % trigger log) is first, if one is present.
+            istsv = false(numel(files),1);
+            for i = 1:numel(files)
+                [~,~,ext] = fileparts(files{i});
+                istsv(i) = strcmpi(ext, '.tsv');
+            end
+            idx = find(istsv, 1, 'first');
+            if ~isempty(idx)
+                rest = (1:numel(files))';
+                rest(idx) = [];
+                files = files([idx; rest]);
+            end
+        end % tsv_first
+
+        function tf = covers_all(files, regexes)
+            % COVERS_ALL - true if, for every regex in REGEXES, at least one
+            % file in FILES has a basename matching it (an AND over the
+            % configured FileParameters).
+            tf = true;
+            for r = 1:numel(regexes)
+                matched = false;
+                for i = 1:numel(files)
+                    [~, nm, ext] = fileparts(files{i});
+                    if ~isempty(regexp([nm ext], regexes{r}, 'once'))
+                        matched = true;
+                        break;
+                    end
+                end
+                if ~matched
+                    tf = false;
+                    return;
+                end
+            end
+        end % covers_all
     end % static methods
 end


### PR DESCRIPTION
## Summary

Fixes a confusing `epochprobemap` error from `vhajbpod_np` (AJBPod-on-Neuropixels/SpikeGLX) sessions, e.g.:

```
Error using ndi.setup.epoch.epochprobemap_daqsystem_vhlab (line 171)
Expected file .Epoch_1_g0_t0.imec0.ap.<hash>.epochprobemap to include the string channelgrouping.
```

That filename is not a real file — it is the *default hidden* epoch-probe-map name NDI falls back to when it cannot find the configured probe-map source. Root cause: `vhlab_np_epochdir` formed an epoch for any `*_g0` directory that matched *any* `FileParameter`, so a run with only the SpikeGLX `nidq`/`imec` files (but no stimulus log) became a phantom epoch whose probe map could not be resolved.

## Changes

**`vhlab_np_epochdir` — one epoch per `Epoch_Set`, full AND match** (`bec87e2`)
- Each `Epoch_Set_N` subdirectory of a `*_g0` run becomes one epoch, pooling that set's `*_stimulus_triggers_log.tsv` + `*_summary_log.json` with the shared `nidq`/`imec` files at the top of the run directory.
- A set forms an epoch only if the combined group satisfies **every** `FileParameter` (an AND, matching stock `ndi.file.navigator.epochdir` semantics), so partial matches no longer create phantom epochs.
- `epochid` is now `<g0dir>_<Epoch_Set_dir>` so multiple sets in one run get distinct ids and distinct hidden bookkeeping files (the `.tsv` is ordered first in the group).

**`VHAudreyBPod` — per-`Epoch_Set` NI-DAQ trigger assignment** (`3bda216`)
- A single NI-DAQ recording is shared by every `Epoch_Set` in a run and records all sets' trigger edges. The reader now reads the whole edge train, enumerates the run's stimulus logs, orders them chronologically, and returns only the contiguous slice of edges belonging to the set being read (previously every set got the leading slice, because `readNidqTriggers` returned all edges and `buildAudreyBPodEvents` kept the first N).
- Requires `#rising == #falling == total stimuli across the run's logs` (one trigger per stimulus) and raises a **loud error** with the counts and directory otherwise, instead of silently mis-assigning triggers.

No DAQ-system configuration changes are needed: the existing `FileParameters` already list all required files, and events remain on the `nidq`/`imec` `dev_local_time` clock (shared with `vhneuropixelsGLX` via the filematch rule), so no new sync rule or sync DAQ system is required.

## Testing

Verified by code inspection; MATLAB was not available in the authoring environment to execute. Recommend running against a real multi-`Epoch_Set` SpikeGLX session to confirm chronological ordering and the trigger-count check on live data.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_011RHTaaMQrh884LtmwNFWbE)_