### PR TITLE
Fix Windows SQLite-locked teardown: close all connections before rmdir (#870)

### DIFF
--- a/src/ndi/+ndi/+dataset/dir.m
+++ b/src/ndi/+ndi/+dataset/dir.m
@@ -193,9 +193,11 @@ classdef dir < ndi.dataset
             end
 
             if strcmpi(areyousure,'yes')
-                % Close any open SQLite handle first so Windows will allow the
-                % did-sqlite.sqlite file to be deleted (issue #870).
-                mksqlite('close');
+                % Close all open SQLite handles first so Windows will allow the
+                % did-sqlite.sqlite file to be deleted. dbid 0 closes every
+                % connection (mksqlite('close') closes only dbid 1); DID
+                % reopens lazily on the next operation (issue #870).
+                mksqlite(0, 'close');
                 rmdir(fullfile(ndi_dataset_dir_obj.path,'.ndi'),'s'); % remove database folder
             else
                 disp('Not erasing session directory folder because user did not indicate they sure.');

--- a/src/ndi/+ndi/+dataset/dir.m
+++ b/src/ndi/+ndi/+dataset/dir.m
@@ -193,6 +193,9 @@ classdef dir < ndi.dataset
             end
 
             if strcmpi(areyousure,'yes')
+                % Close any open SQLite handle first so Windows will allow the
+                % did-sqlite.sqlite file to be deleted (issue #870).
+                mksqlite('close');
                 rmdir(fullfile(ndi_dataset_dir_obj.path,'.ndi'),'s'); % remove database folder
             else
                 disp('Not erasing session directory folder because user did not indicate they sure.');

--- a/src/ndi/+ndi/+session/dir.m
+++ b/src/ndi/+ndi/+session/dir.m
@@ -266,10 +266,13 @@ classdef dir < ndi.session
             if passed
                 p = fullfile(ndi_session_dir_obj.path, '.ndi');
                 if isfolder(p)
-                    % Close any open SQLite handle first so Windows will
+                    % Close all open SQLite handles first so Windows will
                     % allow the did-sqlite.sqlite file to be deleted; an
-                    % open file cannot be removed on Windows (issue #870).
-                    mksqlite('close');
+                    % open file cannot be removed on Windows. dbid 0 closes
+                    % every connection (mksqlite('close') closes only dbid 1,
+                    % which may not be this session's); DID reopens lazily on
+                    % the next operation (issue #870).
+                    mksqlite(0, 'close');
                     rmdir(p, 's');
                 end
                 obj_out = ndi.session.dir.empty();
@@ -434,9 +437,11 @@ classdef dir < ndi.session
             end
 
             if strcmpi(areyousure,'yes')
-                % Close any open SQLite handle first so Windows will allow the
-                % did-sqlite.sqlite file to be deleted (issue #870).
-                mksqlite('close');
+                % Close all open SQLite handles first so Windows will allow the
+                % did-sqlite.sqlite file to be deleted. dbid 0 closes every
+                % connection (mksqlite('close') closes only dbid 1); DID
+                % reopens lazily on the next operation (issue #870).
+                mksqlite(0, 'close');
                 rmdir(fullfile(ndi_session_dir_obj.path,'.ndi'),'s'); % remove database folder
             else
                 disp('Not erasing session directory folder because user did not indicate they sure.');

--- a/src/ndi/+ndi/+session/dir.m
+++ b/src/ndi/+ndi/+session/dir.m
@@ -266,6 +266,10 @@ classdef dir < ndi.session
             if passed
                 p = fullfile(ndi_session_dir_obj.path, '.ndi');
                 if isfolder(p)
+                    % Close any open SQLite handle first so Windows will
+                    % allow the did-sqlite.sqlite file to be deleted; an
+                    % open file cannot be removed on Windows (issue #870).
+                    mksqlite('close');
                     rmdir(p, 's');
                 end
                 obj_out = ndi.session.dir.empty();
@@ -430,6 +434,9 @@ classdef dir < ndi.session
             end
 
             if strcmpi(areyousure,'yes')
+                % Close any open SQLite handle first so Windows will allow the
+                % did-sqlite.sqlite file to be deleted (issue #870).
+                mksqlite('close');
                 rmdir(fullfile(ndi_session_dir_obj.path,'.ndi'),'s'); % remove database folder
             else
                 disp('Not erasing session directory folder because user did not indicate they sure.');

--- a/tests/+ndi/+unittest/+cloud/+sync/BaseSyncTest.m
+++ b/tests/+ndi/+unittest/+cloud/+sync/BaseSyncTest.m
@@ -44,9 +44,10 @@ classdef (Abstract) BaseSyncTest < matlab.unittest.TestCase
         end
 
         function deleteLocalDirectory(testCase)
-            if exist(testCase.testDir, 'dir')
-                rmdir(testCase.testDir, 's');
-            end
+            % Close open SQLite handles before removing the temp directory so
+            % the local dataset's did-sqlite.sqlite is not still locked on
+            % Windows (see issue #870).
+            ndi.unittest.cloud.closeAndRemoveDir(testCase.testDir);
         end
     end
 

--- a/tests/+ndi/+unittest/+cloud/+sync/datasetDemo.m
+++ b/tests/+ndi/+unittest/+cloud/+sync/datasetDemo.m
@@ -15,19 +15,15 @@ classdef datasetDemo < matlab.unittest.TestCase
 
     methods (TestMethodTeardown)
         function teardownDataset(testCase)
-            % Clean up local dataset
+            % Clean up local dataset. Close open SQLite handles before
+            % removing the directories so their did-sqlite.sqlite files are
+            % not still locked on Windows (see issue #870).
             if ~isempty(testCase.ndiDatasetToUpload)
-                path = testCase.ndiDatasetToUpload.path;
-                if isfolder(path)
-                    rmdir(path, 's');
-                end
+                ndi.unittest.cloud.closeAndRemoveDir(testCase.ndiDatasetToUpload.path);
             end
             % Clean up downloaded dataset
             if ~isempty(testCase.ndiDatasetDownloaded)
-                path = testCase.ndiDatasetDownloaded.path;
-                if isfolder(path)
-                    rmdir(path, 's');
-                end
+                ndi.unittest.cloud.closeAndRemoveDir(testCase.ndiDatasetDownloaded.path);
             end
             % Delete remote dataset
             if ~isempty(testCase.cloudDatasetId)
@@ -118,7 +114,7 @@ classdef datasetDemo < matlab.unittest.TestCase
             % 1. Make a dataset and add 2 ingested sessions with documents.
             % The setup already created a dataset with 1 session. We will add a second one.
             session2 = ndi.unittest.session.buildSession.withDocsAndFiles();
-            testCase.addTeardown(@rmdir, session2.path(), 's');
+            testCase.addTeardown(@ndi.unittest.cloud.closeAndRemoveDir, session2.path());
 
             testCase.ndiDatasetToUpload.add_ingested_session(session2);
 
@@ -140,7 +136,7 @@ classdef datasetDemo < matlab.unittest.TestCase
             % 3. Download the dataset to a new (temporary) location
             tempFolder1 = tempname;
             mkdir(tempFolder1);
-            testCase.addTeardown(@rmdir, tempFolder1, 's');
+            testCase.addTeardown(@ndi.unittest.cloud.closeAndRemoveDir, tempFolder1);
 
             pause(5); % Allow cloud to settle
 
@@ -152,11 +148,11 @@ classdef datasetDemo < matlab.unittest.TestCase
 
             % 4. Add two more ingested sessions to the local dataset
             session3 = ndi.unittest.session.buildSession.withDocsAndFiles();
-            testCase.addTeardown(@rmdir, session3.path(), 's');
+            testCase.addTeardown(@ndi.unittest.cloud.closeAndRemoveDir, session3.path());
             testCase.ndiDatasetToUpload.add_ingested_session(session3);
 
             session4 = ndi.unittest.session.buildSession.withDocsAndFiles();
-            testCase.addTeardown(@rmdir, session4.path(), 's');
+            testCase.addTeardown(@ndi.unittest.cloud.closeAndRemoveDir, session4.path());
             testCase.ndiDatasetToUpload.add_ingested_session(session4);
 
             % Verify we have 4 sessions locally
@@ -171,7 +167,7 @@ classdef datasetDemo < matlab.unittest.TestCase
             % 6. Download the dataset to yet another new (temporary) location
             tempFolder2 = tempname;
             mkdir(tempFolder2);
-            testCase.addTeardown(@rmdir, tempFolder2, 's');
+            testCase.addTeardown(@ndi.unittest.cloud.closeAndRemoveDir, tempFolder2);
 
             pause(5);
 

--- a/tests/+ndi/+unittest/+cloud/+sync/emptyDataset.m
+++ b/tests/+ndi/+unittest/+cloud/+sync/emptyDataset.m
@@ -23,9 +23,10 @@ classdef emptyDataset < matlab.unittest.TestCase
                      warning(['Failed to delete remote dataset: ' ME.message]);
                  end
             end
-            if exist(testCase.testDir, 'dir')
-                rmdir(testCase.testDir, 's');
-            end
+            % Close open SQLite handles before removing the temp directory so
+            % the dataset's did-sqlite.sqlite is not still locked on Windows
+            % (see issue #870).
+            ndi.unittest.cloud.closeAndRemoveDir(testCase.testDir);
         end
     end
 

--- a/tests/+ndi/+unittest/+cloud/closeAndRemoveDir.m
+++ b/tests/+ndi/+unittest/+cloud/closeAndRemoveDir.m
@@ -1,0 +1,40 @@
+function closeAndRemoveDir(directoryPath)
+% closeAndRemoveDir - Close open SQLite handles, then remove a directory tree.
+%
+%   ndi.unittest.cloud.closeAndRemoveDir(DIRECTORYPATH)
+%
+%   Closes any open mksqlite database connections and then removes
+%   DIRECTORYPATH (and its contents) if it exists. Intended for use in test
+%   teardown, where a temporary NDI dataset/session directory must be
+%   deleted after the test finishes.
+%
+%   NDI datasets and sessions keep their DID SQLite database
+%   (.ndi/did-sqlite.sqlite) open through mksqlite. On Windows an open file
+%   cannot be deleted, so a teardown that calls rmdir on the dataset
+%   directory before the SQLite handle is released fails with
+%   'MATLAB:RMDIR:SomeDirectoriesNotRemoved'. POSIX platforms silently allow
+%   deleting a still-open file, which is why this only bites on Windows.
+%   Closing the database first makes teardown deterministic across platforms
+%   (see issue #870).
+%
+%   See also: mksqlite, rmdir
+
+    arguments
+        directoryPath (1,1) string
+    end
+
+    % Release any open SQLite database handles so that Windows will permit
+    % the underlying did-sqlite.sqlite file to be deleted. mksqlite('close')
+    % closes all open connections and is a no-op when none are open. It is
+    % guarded because mksqlite may not have been loaded if no SQLite-backed
+    % dataset was opened during the test.
+    try
+        mksqlite('close');
+    catch
+        % Nothing to close (mksqlite not loaded / no open connections).
+    end
+
+    if isfolder(directoryPath)
+        rmdir(directoryPath, 's');
+    end
+end

--- a/tests/+ndi/+unittest/+cloud/closeAndRemoveDir.m
+++ b/tests/+ndi/+unittest/+cloud/closeAndRemoveDir.m
@@ -23,13 +23,18 @@ function closeAndRemoveDir(directoryPath)
         directoryPath (1,1) string
     end
 
-    % Release any open SQLite database handles so that Windows will permit
-    % the underlying did-sqlite.sqlite file to be deleted. mksqlite('close')
-    % closes all open connections and is a no-op when none are open. It is
-    % guarded because mksqlite may not have been loaded if no SQLite-backed
-    % dataset was opened during the test.
+    % Release ALL open SQLite database handles so that Windows will permit
+    % the underlying did-sqlite.sqlite file to be deleted. We must pass
+    % dbid 0 here: mksqlite('close') defaults to dbid 1 and closes only the
+    % first connection, but these tests keep several datasets/sessions open
+    % at once (the local dataset plus datasets that sync downloads), so the
+    % connection locking the directory being removed is often not dbid 1.
+    % mksqlite(0, 'close') closes every open connection; DID reopens lazily
+    % on the next operation, so this is safe (issue #870). The call is
+    % guarded because mksqlite may not be loaded if no SQLite-backed dataset
+    % was opened during the test.
     try
-        mksqlite('close');
+        mksqlite(0, 'close');
     catch
         % Nothing to close (mksqlite not loaded / no open connections).
     end

--- a/tests/+ndi/+unittest/+cloud/testNdiQuery.m
+++ b/tests/+ndi/+unittest/+cloud/testNdiQuery.m
@@ -42,18 +42,14 @@ classdef testNdiQuery < matlab.unittest.TestCase
 
     methods (Access = private)
         function teardownDataset(testCase)
-            % Clean up local
+            % Clean up local. Close open SQLite handles before removing the
+            % dataset/session directories so their did-sqlite.sqlite files are
+            % not still locked on Windows (see issue #870).
              if ~isempty(testCase.Dataset)
-                 path = testCase.Dataset.path;
-                 if isfolder(path)
-                     rmdir(path, 's');
-                 end
+                 ndi.unittest.cloud.closeAndRemoveDir(testCase.Dataset.path);
              end
              if ~isempty(testCase.Session)
-                 path = testCase.Session.path;
-                 if isfolder(path)
-                     rmdir(path, 's');
-                 end
+                 ndi.unittest.cloud.closeAndRemoveDir(testCase.Session.path);
              end
 
              % Clean up remote


### PR DESCRIPTION
## Summary
On Windows, NDI cloud/DB tests that create a local SQLite-backed dataset errored during **teardown**: the `.ndi\did-sqlite.sqlite` file was still open, so `rmdir` of the temp directory failed with `MATLAB:RMDIR:SomeDirectoriesNotRemoved`. Windows will not delete an open file; POSIX platforms silently allow it, which is why this only surfaced once the cloud tests ran on `windows-latest`.

Fixes #870.

## Root cause
Deletion paths removed the dataset/session `.ndi` folder (which holds `did-sqlite.sqlite`) without releasing the open SQLite handle. The existing `mksqlite('close')` idiom scattered in `ndi.dataset` was also insufficient: `mksqlite('close')` defaults to **dbid 1** and closes only the first connection, but these tests keep several datasets/sessions open at once (the local dataset plus datasets that sync downloads), so the connection locking the directory under teardown was frequently not dbid 1 and stayed open. `mksqlite(0, 'close')` closes **every** open connection; DID reopens connections lazily on the next operation, so closing all is safe.

## Changes
**Tests**
- New shared helper `ndi.unittest.cloud.closeAndRemoveDir` — calls `mksqlite(0,'close')` then removes the directory.
- Routed the cloud test teardowns through it: `BaseSyncTest` (covers all `ndi.unittest.cloud.sync.*` subclasses), `testNdiQuery`, `emptyDataset`, and `datasetDemo` (including its `addTeardown(@rmdir, …)` calls).

**Real (non-test) code** — same latent Windows bug in the deletion methods:
- `ndi.session.dir/deleteSessionDataStructures`
- `ndi.session.dir/database_erase`
- `ndi.dataset.dir/dataset_erase`

Each now calls `mksqlite(0,'close')` before removing the `.ndi` folder.

## Verification
Manual **Test NDI Cloud Api (Cross-Platform)** matrix run on this branch (commit 26d0638), env `prod`:

| OS | Result |
|---|---|
| ubuntu-latest | ✅ pass |
| windows-latest | ✅ pass (was 121P / 16F / 17I — now all green) |
| macos-latest | ❌ pre-existing, unrelated: `mksqlite.mexmaca64` cannot load `libMatlabEngine.dylib` (binary-vs-MATLAB-version mismatch, tracked/fixed separately upstream). Every failure is at `mksqlite(0,'open')` during setup; none are the `RMDIR` teardown error. |

## Follow-up
The recurring need to reach for a global `mksqlite('close')` is itself a smell — the SQLite database object lacks a deterministic per-object `close()`. Tracked in #873 (cross-repo: ndi-matlab + did-matlab), not addressed here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01TERbKM6fTFk7KdFw4DfFmU)_