### PR TITLE
Skip samplerate query for eventmarktext channels in mfdaq reader

### DIFF
--- a/src/ndi/+ndi/+daq/+reader/mfdaq.m
+++ b/src/ndi/+ndi/+daq/+reader/mfdaq.m
@@ -869,11 +869,19 @@ classdef mfdaq < ndi.daq.reader
                     % will this work for all channel types? Probably not
                     [underlying_format,mypoly,datasize] = ndi_daqreader_mfdaq_obj.underlying_datatype(epochfiles,...
                         types{i},[ci(chan_entries_indexes(group_indexes)).number]);
-                    sample_rates_here = [];
-                    for k=1:numel(group_indexes)
-                        sample_rates_here(k) = ndi_daqreader_mfdaq_obj.samplerate(epochfiles, ...
-                            ci(chan_entries_indexes(group_indexes(k))).type,...
-                            ci(chan_entries_indexes(group_indexes(k))).number);
+                    % event/marker/text channels are timestamped events with no scalar
+                    % sample rate, so do not query samplerate for them (the eventmarktext
+                    % ingestion branch below never uses it). This mirrors Step 1, which
+                    % leaves these channel types at NaN.
+                    if strcmp(types{i},'eventmarktext')
+                        sample_rates_here = nan(1,numel(group_indexes));
+                    else
+                        sample_rates_here = [];
+                        for k=1:numel(group_indexes)
+                            sample_rates_here(k) = ndi_daqreader_mfdaq_obj.samplerate(epochfiles, ...
+                                ci(chan_entries_indexes(group_indexes(k))).type,...
+                                ci(chan_entries_indexes(group_indexes(k))).number);
+                        end
                     end
 
                     sample_rates_here_unique = unique(sample_rates_here);


### PR DESCRIPTION
## Summary
Fixed an issue where the mfdaq DAQ reader was attempting to query sample rates for eventmarktext channels, which are timestamped events that don't have a scalar sample rate.

## Key Changes
- Added a type check to skip the `samplerate()` query when processing eventmarktext channels
- For eventmarktext channels, `sample_rates_here` is now initialized to `nan(1,numel(group_indexes))` instead of querying the samplerate method
- This behavior now mirrors Step 1 of the reader, which leaves eventmarktext channel sample rates at NaN
- Added explanatory comments noting that eventmarktext channels are timestamped events and that the eventmarktext ingestion branch doesn't use sample rate information

## Implementation Details
The change wraps the sample rate query loop in a conditional that checks if the current channel type is 'eventmarktext'. This prevents unnecessary method calls and potential errors when trying to retrieve sample rates for channel types that don't have them, while maintaining backward compatibility for all other channel types.

https://claude.ai/code/session_01VM8UDyRbtGSdhdX1SRpjpM