### PR TITLE
Update GMC_Sorter export to support Version 4 multi-shank API

### DIFF
--- a/src/ndi/+ndi/+fun/+export/gmcSorter.m
+++ b/src/ndi/+ndi/+fun/+export/gmcSorter.m
@@ -13,15 +13,28 @@ function outputFolders = gmcSorter(probe, outputFolder, options)
 % written for you), then open the resulting spike_prop/ folder in the
 % GMC_Sorter GUI.
 %
+% This targets GMC_Sorter Version 4. Version 4's extract_spike_features takes
+% a CH_ORDER argument (0-based recording channel indices) that selects and
+% orders the channels each pass loads, and its own driver uses that to run one
+% pass PER SHANK. The generated run_gmc_extract.py follows that structure: the
+% probe's shank assignment (the Kilosort 'kcoords' from its geometry) becomes
+% one extract_spike_features pass per shank, channels with no electrode site
+% are left out of ch_order, and each pass's results are additionally saved as
+% properties.mat the way GMC_Sorter's main.py does.
+%
 % For each exported epoch this writes a self-contained GMC_Sorter input
 % folder containing:
 %   [baseName]_samples.dat       int16 voltage, channel-interleaved
 %   [baseName]_timestamps.dat    int64 sample times (microseconds)
+%   channel_info.csv             per channel: index, [x y] (microns), shank,
+%                                  connected -- the per-shank ch_order/ch_map
+%                                  source for the Version 4 driver
 %   channel_positions.csv        [x y] electrode positions (microns), the
-%                                  ch_map GMC_Sorter's extractor needs
-%   channel_map.mat              same positions as xcoords/ycoords/ch_map
+%                                  whole-probe ch_map
+%   channel_map.mat              same positions as xcoords/ycoords/kcoords/
+%                                  connected/ch_map
 %   [baseName].metadata          epoch/sample bookkeeping
-%   run_gmc_extract.py           ready-to-run GMC_Sorter driver
+%   run_gmc_extract.py           ready-to-run GMC_Sorter Version 4 driver
 %
 % The int16 samples are written as int16 = round(multiplier * physical),
 % column-interleaved so that GMC_Sorter's raw_data.py reshapes them as
@@ -35,11 +48,14 @@ function outputFolders = gmcSorter(probe, outputFolder, options)
 % 'epoch_<id>' subfolder (GMC_Sorter's dat_t_s reader expects one recording
 % per folder). OUTPUTFOLDERS is a cellstr of the folder(s) written.
 %
-% CHANNEL MAP: the [x y] positions are read from PROBE's stored geometry with
-% NDI.FUN.PROBE.GEOMETRY.TOKILOSORTMAP, aligned to the exported channel order.
-% If PROBE has no geometry document, a default single-column linear map
-% (x = 0, y spaced by 'spacing' microns) is written with a warning; pass
-% 'channelPositions' to supply the true geometry explicitly.
+% CHANNEL MAP: the [x y] positions, the shank id of each channel, and which
+% channels carry an electrode site are read from PROBE's stored geometry with
+% NDI.FUN.PROBE.GEOMETRY.TOKILOSORTMAP (xcoords/ycoords, kcoords, connected),
+% aligned to the exported channel order. If PROBE has no geometry document, a
+% default single-column linear map (x = 0, y spaced by 'spacing' microns, one
+% shank, all channels connected) is written with a warning; pass
+% 'channelPositions' (and 'shankIndex' / 'connected') to supply the true
+% geometry explicitly.
 %
 % This function's parameters can be modified by passing name/value pairs:
 % --------------------------------------------------------------------------
@@ -56,6 +72,26 @@ function outputFolders = gmcSorter(probe, outputFolder, options)
 % |                         |   precision/clipping.                         |
 % | channelPositions ([])   | n_channels x 2 [x y] positions (microns) in   |
 % |                         |   channel order, overriding the probe geometry|
+% | shankIndex ([])         | n_channels x 1 shank id per channel,          |
+% |                         |   overriding the geometry's kcoords. One      |
+% |                         |   GMC_Sorter pass runs per distinct id.       |
+% | connected ([])          | n_channels x 1 logical, overriding the        |
+% |                         |   geometry's 'connected'. False channels are  |
+% |                         |   exported but left out of the driver's       |
+% |                         |   ch_order, so GMC_Sorter never sorts them.   |
+% | sortByDepth (true)      | Order each shank's ch_order tip-to-base       |
+% |                         |   (ascending y), as GMC_Sorter's              |
+% |                         |   probe_mappings.py does.                     |
+% | gmcProbeName ('')       | Name of a GMC_Sorter built-in probe (see      |
+% |                         |   probe_mappings.get_probe_map). If given, the|
+% |                         |   driver uses GMC's own wiring rather than    |
+% |                         |   the exported channel table -- only correct  |
+% |                         |   if the exported channel order IS that       |
+% |                         |   probe's wiring.                             |
+% | featureOptions ({})     | Name/value cell forwarded to                  |
+% |                         |   extract_spike_features as keyword args,     |
+% |                         |   e.g. {'refr_space',150,'wvf_space',150}.    |
+% | makePlots (false)       | make_plots for extract_spike_features.        |
 % | horizontalAxis          | Which probe axis becomes x: 'leftright' or    |
 % |   ('leftright')         |   'frontback' (y is always depth).            |
 % | spacing (25)            | Default linear y-spacing (microns) used only  |
@@ -71,10 +107,12 @@ function outputFolders = gmcSorter(probe, outputFolder, options)
 % Example:
 %   S = ndi.session.dir('/path/to/session');
 %   p = S.getprobes('type','n-trode'); p = p{1};
-%   ndi.fun.export.gmcSorter(p, '/tmp/gmc_export');
-%   % then, on a machine with GMC_Sorter installed:
+%   ndi.fun.export.gmcSorter(p, '/tmp/gmc_export', ...
+%       'featureOptions', {'refr_space',150,'wvf_space',150,'noise_space',NaN});
+%   % then, on a machine with GMC_Sorter (Version 4) installed:
 %   %   python /tmp/gmc_export/run_gmc_extract.py
-%   % and open /tmp/gmc_export in the GMC_Sorter GUI.
+%   % and open /tmp/gmc_export (or /tmp/gmc_export/Sh0 for a multi-shank
+%   % probe) in the GMC_Sorter GUI.
 %
 % See also: NDI.FUN.EXPORT.GMCSORTERWRITE, NDI.FUN.EXPORT.WRITEGMCSIDECARS,
 %   NDI.FUN.PROBE.EXPORT.BINARY, NDI.FUN.PROBE.GEOMETRY.TOKILOSORTMAP,
@@ -87,6 +125,12 @@ function outputFolders = gmcSorter(probe, outputFolder, options)
         options.baseName (1,:) char = 'RawData'
         options.multiplier (1,1) double = 1
         options.channelPositions double = []
+        options.shankIndex double = []
+        options.connected = []
+        options.sortByDepth (1,1) logical = true
+        options.gmcProbeName (1,:) char = ''
+        options.featureOptions cell = {}
+        options.makePlots (1,1) logical = false
         options.horizontalAxis (1,:) char {mustBeMember(options.horizontalAxis,{'leftright','frontback'})} = 'leftright'
         options.spacing (1,1) double = 25
         options.gmcSorterPath (1,:) char = ''
@@ -180,12 +224,16 @@ function outputFolders = gmcSorter(probe, outputFolder, options)
             numChannels = 0;
         end
 
-        % resolve channel positions [x y] aligned to the exported channel order
-        channelPositions = local_channel_positions(probe, numChannels, options);
+        % resolve channel geometry ([x y], shank, connected) aligned to the
+        % exported channel order
+        G = local_channel_geometry(probe, numChannels, options);
 
         epoch_sample_counts = local_epoch_sample_count(probe, epoch_id);
 
-        ndi.fun.export.writeGmcSidecars(thisFolder, options.baseName, channelPositions, ...
+        ndi.fun.export.writeGmcSidecars(thisFolder, options.baseName, G.positions, ...
+            'shankIndex', G.shank, 'connected', G.connected, ...
+            'sortByDepth', options.sortByDepth, 'gmcProbeName', options.gmcProbeName, ...
+            'featureOptions', options.featureOptions, 'makePlots', options.makePlots, ...
             'epochSampleCounts', epoch_sample_counts, 'epochSampleRates', sr, ...
             'sampleRate', sr, 'multiplier', options.multiplier, ...
             'probeName', probe.elementstring(), 'gmcSorterPath', options.gmcSorterPath, ...
@@ -209,37 +257,66 @@ function local_write_timestamps(fid, t_seconds)
 end
 
 % =========================================================================
-% Channel positions [x y], aligned to the exported channel order
+% Channel geometry aligned to the exported channel order: [x y] positions,
+% the shank id of each channel (GMC_Sorter Version 4 sorts one shank per
+% pass), and which channels actually carry an electrode site.
 % =========================================================================
-function pos = local_channel_positions(probe, numChannels, options)
+function G = local_channel_geometry(probe, numChannels, options)
+    G = struct('positions', [], 'shank', [], 'connected', []);
+
     if ~isempty(options.channelPositions)
-        pos = options.channelPositions;
-        if size(pos,1) ~= numChannels && numChannels>0
+        G.positions = options.channelPositions;
+        if size(G.positions,1) ~= numChannels && numChannels>0
             error('ndi:fun:export:gmcSorter:posmismatch', ...
                 ['channelPositions has %d rows but the export has %d channels; ' ...
-                 'they must match.'], size(pos,1), numChannels);
+                 'they must match.'], size(G.positions,1), numChannels);
         end
-        return;
+    else
+        S = probe.session;
+        mapFile = [tempname '.mat'];
+        cleanup = onCleanup(@() local_delete(mapFile)); %#ok<NASGU>
+        tf = ndi.fun.probe.geometry.toKilosortMap(S, probe, mapFile, ...
+            'num_channels', numChannels, 'horizontal_axis', options.horizontalAxis, ...
+            'verbose', options.verbose);
+        if tf && isfile(mapFile)
+            m = load(mapFile, 'xcoords', 'ycoords', 'kcoords', 'connected');
+            G.positions = [m.xcoords(:) m.ycoords(:)];
+            if isfield(m,'kcoords') && ~isempty(m.kcoords)
+                G.shank = double(m.kcoords(:));
+            end
+            if isfield(m,'connected') && ~isempty(m.connected)
+                G.connected = logical(m.connected(:));
+            end
+        else
+            if options.verbose
+                warning('ndi:fun:export:gmcSorter:nogeometry', ...
+                    ['Probe %s has no geometry document; writing a default single-column ' ...
+                     'linear channel map (x=0, y spaced by %g um, one shank). Pass ' ...
+                     'channelPositions for the real geometry.'], ...
+                    probe.elementstring(), options.spacing);
+            end
+            y = (0:max(numChannels-1,0)).' * options.spacing;
+            G.positions = [zeros(numel(y),1) y];
+        end
     end
 
-    S = probe.session;
-    mapFile = [tempname '.mat'];
-    cleanup = onCleanup(@() local_delete(mapFile));
-    tf = ndi.fun.probe.geometry.toKilosortMap(S, probe, mapFile, ...
-        'num_channels', numChannels, 'horizontal_axis', options.horizontalAxis, ...
-        'verbose', options.verbose);
-    if tf && isfile(mapFile)
-        m = load(mapFile, 'xcoords', 'ycoords');
-        pos = [m.xcoords(:) m.ycoords(:)];
-    else
-        if options.verbose
-            warning('ndi:fun:export:gmcSorter:nogeometry', ...
-                ['Probe %s has no geometry document; writing a default single-column ' ...
-                 'linear channel map (x=0, y spaced by %g um). Pass channelPositions ' ...
-                 'for the real geometry.'], probe.elementstring(), options.spacing);
-        end
-        y = (0:max(numChannels-1,0)).' * options.spacing;
-        pos = [zeros(numel(y),1) y];
+    % explicit overrides win over whatever the geometry supplied
+    if ~isempty(options.shankIndex)
+        G.shank = double(options.shankIndex(:));
+    end
+    if ~isempty(options.connected)
+        G.connected = logical(options.connected(:));
+    end
+
+    nPos = size(G.positions,1);
+    if isempty(G.shank),     G.shank     = ones(nPos,1);  end
+    if isempty(G.connected), G.connected = true(nPos,1);  end
+
+    if nPos>0 && ~any(G.connected)
+        warning('ndi:fun:export:gmcSorter:noconnected', ...
+            ['No channel of probe %s is marked connected; the generated driver ' ...
+             'would have nothing to sort. Pass ''connected'' explicitly.'], ...
+            probe.elementstring());
     end
 end
 

--- a/src/ndi/+ndi/+fun/+export/gmcSorterWrite.m
+++ b/src/ndi/+ndi/+fun/+export/gmcSorterWrite.m
@@ -25,6 +25,11 @@ function gmcSorterWrite(outputFolder, samples, timestamps, channelPositions, opt
 % |                   |   (microns), in the same channel order as SAMPLES.  |
 % --------------------------------------------------------------------------
 %
+% The sidecars and the generated driver target GMC_Sorter Version 4: pass
+% 'shankIndex' for a multi-shank probe and the driver runs one
+% extract_spike_features(..., ch_order=...) pass per shank, as GMC_Sorter's
+% own main.py does. See NDI.FUN.EXPORT.WRITEGMCSIDECARS.
+%
 % The two '.dat' files are written little-endian (matching raw_data.py's
 % native-endian numpy reads on x86). GMC_Sorter derives from their sizes:
 %   n_time_samples = sizeof(timestamps)/8 (int64)
@@ -52,6 +57,17 @@ function gmcSorterWrite(outputFolder, samples, timestamps, channelPositions, opt
 % |                       |   driver. If empty, inferred from TIMESTAMPS.   |
 % | probeName ('')        | Probe elementstring recorded in the metadata.   |
 % | writeSidecars (true)  | Write channel map / metadata / driver too.      |
+% | shankIndex ([])       | n_channels x 1 shank id per channel; one        |
+% |                       |   GMC_Sorter pass runs per distinct id. Empty   |
+% |                       |   => a single shank.                            |
+% | connected ([])        | n_channels x 1 logical; false channels are      |
+% |                       |   written but left out of the driver's ch_order.|
+% | sortByDepth (true)    | Order each shank's ch_order tip-to-base.        |
+% | gmcProbeName ('')     | Use GMC_Sorter's probe_mappings wiring for this |
+% |                       |   named probe instead of the exported table.    |
+% | featureOptions ({})   | Name/value cell forwarded to                    |
+% |                       |   extract_spike_features as keyword arguments.  |
+% | makePlots (false)     | make_plots for extract_spike_features.          |
 % | gmcSorterPath ('')    | Path to the GMC_Sorter checkout for the driver. |
 % | verbose (1)           | 0/1 Should we be verbose?                       |
 % --------------------------------------------------------------------------
@@ -75,6 +91,12 @@ function gmcSorterWrite(outputFolder, samples, timestamps, channelPositions, opt
         options.sampleRate double = []
         options.probeName (1,:) char = ''
         options.writeSidecars (1,1) logical = true
+        options.shankIndex double = []
+        options.connected = []
+        options.sortByDepth (1,1) logical = true
+        options.gmcProbeName (1,:) char = ''
+        options.featureOptions cell = {}
+        options.makePlots (1,1) logical = false
         options.gmcSorterPath (1,:) char = ''
         options.verbose (1,1) double = 1
     end
@@ -136,6 +158,9 @@ function gmcSorterWrite(outputFolder, samples, timestamps, channelPositions, opt
             sr = 1e6 / median(diff(timestamps)*1e6); % = 1/median(diff(t))
         end
         ndi.fun.export.writeGmcSidecars(outputFolder, options.baseName, channelPositions, ...
+            'shankIndex', options.shankIndex, 'connected', options.connected, ...
+            'sortByDepth', options.sortByDepth, 'gmcProbeName', options.gmcProbeName, ...
+            'featureOptions', options.featureOptions, 'makePlots', options.makePlots, ...
             'epochSampleCounts', nSamples, 'epochSampleRates', sr, 'sampleRate', sr, ...
             'multiplier', options.multiplier, 'probeName', options.probeName, ...
             'gmcSorterPath', options.gmcSorterPath, 'verbose', options.verbose);

--- a/src/ndi/+ndi/+fun/+export/writeGmcSidecars.m
+++ b/src/ndi/+ndi/+fun/+export/writeGmcSidecars.m
@@ -11,34 +11,76 @@ function writeGmcSidecars(outputFolder, baseName, channelPositions, options)
 % rate from their sizes, but its feature extractor (sp_feature_ext.py,
 % extract_spike_features) additionally needs a channel map: an (n_channels x 2)
 % array of [x y] electrode positions (microns) in the SAME channel order as the
-% samples file. This function writes that map (and a couple of conveniences) so
-% the exported folder is a self-contained, runnable GMC_Sorter input.
+% channels that pass loads. This function writes that map (and a couple of
+% conveniences) so the exported folder is a self-contained, runnable
+% GMC_Sorter input.
+%
+% This targets GMC_Sorter Version 4, whose extract_spike_features takes a
+% CH_ORDER argument -- a list of 0-based recording channel indices that selects
+% and reorders the channels a pass loads (raw_data.py indexes the samples file
+% with it). Version 4's own driver (main.py) uses that to run ONE PASS PER
+% PROBE SHANK, with each pass's ch_map holding just that shank's sites in
+% ch_order order. The generated driver here does the same, deriving the shanks
+% from the exported channel table.
 %
 % Files written into OUTPUTFOLDER:
 % --------------------------------------------------------------------------
 % | File                     | Contents                                     |
 % |--------------------------|----------------------------------------------|
+% | channel_info.csv         | Header row 'channel,x,y,shank,connected'     |
+% |                          |   then one row per exported channel: 0-based |
+% |                          |   channel index, [x y] in microns, shank id, |
+% |                          |   and 1/0 for whether a site is wired to it. |
+% |                          |   This is what the driver groups into the    |
+% |                          |   per-shank ch_order / ch_map pairs.         |
 % | channel_positions.csv    | n_channels rows of "x,y" (microns), channel  |
-% |                          |   order. Load in Python with np.loadtxt(...,  |
-% |                          |   delimiter=',') and pass as ch_map.         |
-% | channel_map.mat          | xcoords, ycoords (1 x n_channels) and ch_map |
-% |                          |   (n_channels x 2 = [xcoords' ycoords']).    |
+% |                          |   order. The whole-probe ch_map, kept for    |
+% |                          |   single-shank use and for reading the map   |
+% |                          |   without parsing the header row.            |
+% | channel_map.mat          | xcoords, ycoords, kcoords (shank), connected |
+% |                          |   (1 x n_channels) and ch_map (n_channels x  |
+% |                          |   2 = [xcoords' ycoords']).                  |
 % | [baseName].metadata      | epoch_sample_counts, epoch_sample_rates,     |
-% |                          |   num_channels, multiplier, sample_rate,     |
-% |                          |   probe_name, file_struct ('dat_t_s'),       |
-% |                          |   samples_file, timestamps_file. Written with|
-% |                          |   vlt.file.saveStructArray (same as          |
-% |                          |   ndi.fun.probe.export.binary).              |
-% | run_gmc_extract.py       | A ready-to-run driver that calls             |
-% |                          |   extract_spike_features on this folder,      |
-% |                          |   producing spike_prop/batch_*_spike_         |
-% |                          |   properties.npz for the GMC_Sorter GUI.     |
+% |                          |   num_channels, num_shanks, multiplier,      |
+% |                          |   sample_rate, probe_name, file_struct        |
+% |                          |   ('dat_t_s'), samples_file, timestamps_file.|
+% |                          |   Written with vlt.file.saveStructArray (same|
+% |                          |   as ndi.fun.probe.export.binary).           |
+% | run_gmc_extract.py       | A ready-to-run Version 4 driver: one         |
+% |                          |   extract_spike_features(..., ch_order=...)  |
+% |                          |   pass per shank, then properties.mat for    |
+% |                          |   each pass (the same concatenation          |
+% |                          |   GMC_Sorter's main.py does), producing      |
+% |                          |   spike_prop/batch_*_spike_properties.npz    |
+% |                          |   for the GMC_Sorter GUI.                    |
 % --------------------------------------------------------------------------
 %
 % Name/value pairs:
 % --------------------------------------------------------------------------
 % | Parameter (default)       | Description                                 |
 % |---------------------------|---------------------------------------------|
+% | shankIndex ([])           | n_channels x 1 shank id per channel (the    |
+% |                           |   Kilosort 'kcoords'). Empty => all channels|
+% |                           |   on one shank. Channels sharing an id are  |
+% |                           |   sorted together in one GMC pass.          |
+% | connected ([])            | n_channels x 1 logical: does this channel   |
+% |                           |   have an electrode site? Empty => all true. |
+% |                           |   Unconnected channels are left out of      |
+% |                           |   ch_order so GMC never sorts them.         |
+% | sortByDepth (true)        | Order each shank's ch_order tip-to-base     |
+% |                           |   (ascending y), matching the convention in  |
+% |                           |   GMC_Sorter's probe_mappings.py.           |
+% | gmcProbeName ('')         | Name of a GMC_Sorter built-in probe (see    |
+% |                           |   probe_mappings.get_probe_map, e.g.        |
+% |                           |   'KN_UCLA_64M'). If given, the driver uses |
+% |                           |   GMC's own wiring instead of the exported  |
+% |                           |   channel table. Only correct if the export |
+% |                           |   channel order IS that probe's wiring.     |
+% | featureOptions ({})       | Name/value cell passed through to           |
+% |                           |   extract_spike_features as keyword         |
+% |                           |   arguments, e.g. {'refr_space',150,        |
+% |                           |   'wvf_space',150,'noise_space',NaN}.       |
+% | makePlots (false)         | make_plots for extract_spike_features.      |
 % | epochSampleCounts ([])    | Per-epoch sample counts (for metadata).     |
 % | epochSampleRates ([])     | Per-epoch sample rates, Hz (for metadata).  |
 % | sampleRate ([])           | Representative sample rate, Hz (for driver  |
@@ -61,6 +103,12 @@ function writeGmcSidecars(outputFolder, baseName, channelPositions, options)
         outputFolder (1,:) char
         baseName (1,:) char
         channelPositions (:,2) double
+        options.shankIndex double = []
+        options.connected = []
+        options.sortByDepth (1,1) logical = true
+        options.gmcProbeName (1,:) char = ''
+        options.featureOptions cell = {}
+        options.makePlots (1,1) logical = false
         options.epochSampleCounts double = []
         options.epochSampleRates double = []
         options.sampleRate double = []
@@ -79,10 +127,33 @@ function writeGmcSidecars(outputFolder, baseName, channelPositions, options)
     xcoords = channelPositions(:,1).';   % 1 x n_channels
     ycoords = channelPositions(:,2).';   % 1 x n_channels
 
+    [kcoords, connected] = local_shank_and_connected(numChannels, ...
+        options.shankIndex, options.connected);
+
+    if mod(numel(options.featureOptions),2)~=0
+        error('ndi:fun:export:writeGmcSidecars:featureOptions', ...
+            'featureOptions must be a cell array of name/value pairs (got %d elements).', ...
+            numel(options.featureOptions));
+    end
+
     sampleRate = options.sampleRate;
     if isempty(sampleRate) && ~isempty(options.epochSampleRates)
         sampleRate = options.epochSampleRates(1);
     end
+
+    % --- channel_info.csv : the per-shank ch_order/ch_map source -----------
+    infoFile = fullfile(outputFolder, 'channel_info.csv');
+    fid = fopen(infoFile, 'w');
+    if fid<0
+        error('ndi:fun:export:writeGmcSidecars:csv', ...
+            'Unable to open %s for writing.', infoFile);
+    end
+    fprintf(fid, 'channel,x,y,shank,connected\n');
+    for i = 1:numChannels
+        fprintf(fid, '%d,%.6g,%.6g,%d,%d\n', i-1, ...   % 0-based: Python indexes it
+            channelPositions(i,1), channelPositions(i,2), kcoords(i), connected(i));
+    end
+    fclose(fid);
 
     % --- channel_positions.csv : "x,y" per channel, channel order ---------
     csvFile = fullfile(outputFolder, 'channel_positions.csv');
@@ -98,25 +169,29 @@ function writeGmcSidecars(outputFolder, baseName, channelPositions, options)
 
     % --- channel_map.mat --------------------------------------------------
     ch_map = channelPositions; % n_channels x 2 = [x y]
-    save(fullfile(outputFolder, 'channel_map.mat'), 'xcoords', 'ycoords', 'ch_map', '-v7');
+    % kcoords/connected are saved 1 x n_channels, matching xcoords/ycoords
+    mapStruct = struct('xcoords', xcoords, 'ycoords', ycoords, ...
+        'kcoords', kcoords(:).', 'connected', connected(:).', 'ch_map', ch_map);
+    save(fullfile(outputFolder, 'channel_map.mat'), '-struct', 'mapStruct', '-v7');
 
     % --- [baseName].metadata (same writer as ndi.fun.probe.export.binary) -
     epoch_sample_counts = options.epochSampleCounts; %#ok<NASGU>
     epoch_sample_rates  = options.epochSampleRates;  %#ok<NASGU>
     num_channels = numChannels;                      %#ok<NASGU>
+    num_shanks   = numel(unique(kcoords));           %#ok<NASGU>
     multiplier   = options.multiplier;               %#ok<NASGU>
     probe_name   = options.probeName;                %#ok<NASGU>
     file_struct  = 'dat_t_s';                        %#ok<NASGU>
     samples_file    = [baseName '_samples.dat'];     %#ok<NASGU>
     timestamps_file = [baseName '_timestamps.dat'];  %#ok<NASGU>
     metastructure = vlt.data.var2struct('epoch_sample_counts','epoch_sample_rates', ...
-        'num_channels','multiplier','probe_name','file_struct', ...
+        'num_channels','num_shanks','multiplier','probe_name','file_struct', ...
         'samples_file','timestamps_file');
     vlt.file.saveStructArray(fullfile(outputFolder, [baseName '.metadata']), metastructure);
 
-    % --- run_gmc_extract.py : a ready-to-run GMC_Sorter driver ------------
+    % --- run_gmc_extract.py : a ready-to-run GMC_Sorter Version 4 driver ---
     if options.writeDriver
-        local_write_driver(outputFolder, sampleRate, options.gmcSorterPath);
+        local_write_driver(outputFolder, sampleRate, options);
     end
 
     if options.verbose
@@ -124,7 +199,37 @@ function writeGmcSidecars(outputFolder, baseName, channelPositions, options)
     end
 end % writeGmcSidecars
 
-function local_write_driver(outputFolder, sampleRate, gmcSorterPath)
+% =========================================================================
+% Shank ids and connectedness, defaulted and validated against the channels
+% =========================================================================
+function [kcoords, connected] = local_shank_and_connected(numChannels, shankIndex, connectedIn)
+    if isempty(shankIndex)
+        kcoords = ones(numChannels,1);
+    else
+        kcoords = double(shankIndex(:));
+        if numel(kcoords) ~= numChannels
+            error('ndi:fun:export:writeGmcSidecars:shankIndex', ...
+                ['shankIndex has %d elements but the export has %d channels; ' ...
+                 'they must match.'], numel(kcoords), numChannels);
+        end
+    end
+
+    if isempty(connectedIn)
+        connected = true(numChannels,1);
+    else
+        connected = logical(connectedIn(:));
+        if numel(connected) ~= numChannels
+            error('ndi:fun:export:writeGmcSidecars:connected', ...
+                ['connected has %d elements but the export has %d channels; ' ...
+                 'they must match.'], numel(connected), numChannels);
+        end
+    end
+end % local_shank_and_connected
+
+% =========================================================================
+% The GMC_Sorter Version 4 driver script
+% =========================================================================
+function local_write_driver(outputFolder, sampleRate, options)
     driverFile = fullfile(outputFolder, 'run_gmc_extract.py');
     fid = fopen(driverFile, 'w');
     if fid<0
@@ -137,36 +242,197 @@ function local_write_driver(outputFolder, sampleRate, gmcSorterPath)
     else
         srComment = sprintf('~%.6g Hz', sampleRate);
     end
+
     L = {};
     L{end+1} = '#!/usr/bin/env python3';
-    L{end+1} = '"""Auto-generated by ndi.fun.export.gmcSorter (NDI -> GMC_Sorter, Level A).';
+    L{end+1} = '"""Auto-generated by ndi.fun.export.gmcSorter (NDI -> GMC_Sorter Version 4).';
     L{end+1} = '';
     L{end+1} = 'Runs GMC_Sorter''s own spike detector + feature extractor on the raw';
     L{end+1} = 'voltage that NDI exported here (file_struct ''dat_t_s''), producing';
-    L{end+1} = 'spike_prop/batch_*_spike_properties.npz for the GMC_Sorter GUI.';
+    L{end+1} = 'spike_prop/batch_*_spike_properties.npz for the GMC_Sorter GUI plus a';
+    L{end+1} = 'properties.mat for MATLAB/NDI.';
+    L{end+1} = '';
+    L{end+1} = 'One extract_spike_features pass runs per probe shank, as in GMC_Sorter''s';
+    L{end+1} = 'own main.py: ch_order gives the 0-based recording channels that pass';
+    L{end+1} = 'loads (in load order) and ch_map holds those channels'' [x y] positions in';
+    L{end+1} = 'the SAME order. Multi-shank exports write each pass into Sh<n>/.';
     L{end+1} = sprintf('Sample rate: %s.', srComment);
     L{end+1} = '"""';
     L{end+1} = 'import os';
+    L{end+1} = 'import glob';
     L{end+1} = 'import numpy as np';
-    if ~isempty(gmcSorterPath)
+    L{end+1} = 'import scipy.io';
+    if ~isempty(options.gmcSorterPath)
         L{end+1} = 'import sys';
-        L{end+1} = sprintf('sys.path.insert(0, r"%s")  # folder holding sp_feature_ext.py', gmcSorterPath);
+        L{end+1} = sprintf('sys.path.insert(0, r"%s")  # folder holding sp_feature_ext.py', options.gmcSorterPath);
     else
         L{end+1} = '# If sp_feature_ext is not importable, add the GMC_Sorter checkout to sys.path:';
         L{end+1} = '#   import sys; sys.path.insert(0, r"/path/to/GMC_Sorter")';
     end
     L{end+1} = 'from sp_feature_ext import extract_spike_features';
+    if ~isempty(options.gmcProbeName)
+        L{end+1} = 'from probe_mappings import get_probe_map';
+    end
     L{end+1} = '';
-    L{end+1} = 'here = os.path.dirname(os.path.abspath(__file__))';
-    L{end+1} = 'exp_folder = here          # holds *_samples.dat and *_timestamps.dat';
-    L{end+1} = 'out_folder = here          # spike_prop/ is written here';
-    L{end+1} = 'ch_map = np.atleast_2d(np.loadtxt(os.path.join(here, "channel_positions.csv"), delimiter=","))';
+    L{end+1} = 'HERE = os.path.dirname(os.path.abspath(__file__))';
+    L{end+1} = 'EXP_FOLDER = HERE          # holds *_samples.dat and *_timestamps.dat';
+    L{end+1} = 'FILE_STRUCT = "dat_t_s"';
+    L{end+1} = sprintf('MAKE_PLOTS = %s', local_py_bool(options.makePlots));
+    L{end+1} = sprintf('SORT_BY_DEPTH = %s   # order each shank tip-to-base (ascending y)', ...
+        local_py_bool(options.sortByDepth));
+    L{end+1} = sprintf('PROBE_NAME = %s   # "" -> use channel_info.csv; else a probe_mappings name', ...
+        local_py_str(options.gmcProbeName));
+    L{end+1} = ['EXTRACT_KWARGS = dict(' local_py_kwargs(options.featureOptions) ')'];
     L{end+1} = '';
-    L{end+1} = 'extract_spike_features(';
-    L{end+1} = '    exp_folder, "dat_t_s", ch_map, out_folder,';
-    L{end+1} = '    time_interval=(0, float("inf")), make_plots=False,';
-    L{end+1} = ')';
-    L{end+1} = 'print("Done. Point the GMC_Sorter GUI at:", out_folder)';
+    L{end+1} = '';
+    L{end+1} = 'def exported_time_interval():';
+    L{end+1} = '    """The epoch clock span actually exported, in seconds.';
+    L{end+1} = '';
+    L{end+1} = '    extract_spike_features'' own default of (0, inf) resolves inf to';
+    L{end+1} = '    n_samples/sample_rate, i.e. it assumes the recording starts at t=0.';
+    L{end+1} = '    NDI writes the probe''s epoch clock, whose t0 need not be 0, so read the';
+    L{end+1} = '    real first/last timestamp instead. GMC''s binary search is exclusive at';
+    L{end+1} = '    both ends, hence the +1 us so the final sample is included.';
+    L{end+1} = '    """';
+    L{end+1} = '    name = next(f for f in os.listdir(EXP_FOLDER) if f.endswith("_timestamps.dat"))';
+    L{end+1} = '    path = os.path.join(EXP_FOLDER, name)';
+    L{end+1} = '    if os.path.getsize(path) == 0:   # an epoch that exported no samples';
+    L{end+1} = '        raise SystemExit("Timestamps file is empty; nothing to sort.")';
+    L{end+1} = '    ts = np.memmap(path, dtype=np.int64, mode="r")';
+    L{end+1} = '    return (float(ts[0]) / 1e6, float(ts[-1] + 1) / 1e6)';
+    L{end+1} = '';
+    L{end+1} = '';
+    L{end+1} = 'def shanks_from_export():';
+    L{end+1} = '    """Group the channels NDI exported into one (ch_order, ch_map) pair per shank."""';
+    L{end+1} = '    info = np.atleast_2d(np.loadtxt(os.path.join(HERE, "channel_info.csv"),';
+    L{end+1} = '                                    delimiter=",", skiprows=1))';
+    L{end+1} = '    if info.size == 0:';
+    L{end+1} = '        return []';
+    L{end+1} = '    channel = info[:, 0].astype(int)     # 0-based index into the samples file';
+    L{end+1} = '    xy      = info[:, 1:3]';
+    L{end+1} = '    shank   = info[:, 3].astype(int)';
+    L{end+1} = '    good    = info[:, 4].astype(bool)    # channel has an electrode site';
+    L{end+1} = '    out = []';
+    L{end+1} = '    for k in np.unique(shank):';
+    L{end+1} = '        sel = np.flatnonzero((shank == k) & good)';
+    L{end+1} = '        if sel.size == 0:';
+    L{end+1} = '            continue';
+    L{end+1} = '        if SORT_BY_DEPTH:';
+    L{end+1} = '            sel = sel[np.argsort(xy[sel, 1], kind="stable")]';
+    L{end+1} = '        out.append(dict(ch_order=channel[sel].tolist(), ch_map=xy[sel, :]))';
+    L{end+1} = '    return out';
+    L{end+1} = '';
+    L{end+1} = '';
+    L{end+1} = 'def shanks_from_probe_mappings(name):';
+    L{end+1} = '    """Use GMC_Sorter''s own wiring for a named probe instead of the export."""';
+    L{end+1} = '    out = []';
+    L{end+1} = '    for sh in get_probe_map(name):';
+    L{end+1} = '        order = sh["ch_order"]';
+    L{end+1} = '        if order is None:';
+    L{end+1} = '            order = list(range(len(sh["x_position"])))';
+    L{end+1} = '        out.append(dict(';
+    L{end+1} = '            ch_order=list(order),';
+    L{end+1} = '            ch_map=np.column_stack([sh["x_position"], sh["y_position"]]),';
+    L{end+1} = '        ))';
+    L{end+1} = '    return out';
+    L{end+1} = '';
+    L{end+1} = '';
+    L{end+1} = 'def save_properties_mat(folder):';
+    L{end+1} = '    """Concatenate spike_prop/*properties.npz into properties.mat (as main.py does)."""';
+    L{end+1} = '    prop_dir = os.path.join(folder, "spike_prop")';
+    L{end+1} = '    files = sorted(';
+    L{end+1} = '        glob.glob(os.path.join(prop_dir, "*properties.npz")),';
+    L{end+1} = '        key=lambda p: int(next(';
+    L{end+1} = '            (s for s in os.path.splitext(os.path.basename(p))[0].split("_") if s.isdigit()),';
+    L{end+1} = '            "0")),';
+    L{end+1} = '    )';
+    L{end+1} = '    if not files:';
+    L{end+1} = '        print("No spike property files in", prop_dir, "- skipping properties.mat")';
+    L{end+1} = '        return';
+    L{end+1} = '    out = {"properties": np.concatenate([np.load(f)["Properties"] for f in files])}';
+    L{end+1} = '    titles = glob.glob(os.path.join(prop_dir, "property_titles.npz"))';
+    L{end+1} = '    if titles:';
+    L{end+1} = '        out["prop_titles"] = np.load(titles[0])["PropTitles"]';
+    L{end+1} = '    scipy.io.savemat(os.path.join(folder, "properties.mat"), out)';
+    L{end+1} = '    print("Wrote", os.path.join(folder, "properties.mat"))';
+    L{end+1} = '';
+    L{end+1} = '';
+    L{end+1} = 'shanks = shanks_from_probe_mappings(PROBE_NAME) if PROBE_NAME else shanks_from_export()';
+    L{end+1} = 'if not shanks:';
+    L{end+1} = '    raise SystemExit("No channels to sort; check channel_info.csv.")';
+    L{end+1} = '';
+    L{end+1} = 'TIME_INTERVAL = exported_time_interval()   # seconds; narrow to sort a sub-interval';
+    L{end+1} = 'print("Sorting %.3f - %.3f s" % TIME_INTERVAL)';
+    L{end+1} = '';
+    L{end+1} = 'for n, sh in enumerate(shanks):';
+    L{end+1} = '    out_folder = HERE if len(shanks) == 1 else os.path.join(HERE, "Sh%d" % n)';
+    L{end+1} = '    os.makedirs(out_folder, exist_ok=True)';
+    L{end+1} = '    print("Shank %d/%d: %d channels -> %s"';
+    L{end+1} = '          % (n + 1, len(shanks), len(sh["ch_order"]), out_folder))';
+    L{end+1} = '    extract_spike_features(';
+    L{end+1} = '        EXP_FOLDER, FILE_STRUCT, sh["ch_map"], out_folder,';
+    L{end+1} = '        time_interval=TIME_INTERVAL, make_plots=MAKE_PLOTS,';
+    L{end+1} = '        ch_order=sh["ch_order"], **EXTRACT_KWARGS,';
+    L{end+1} = '    )';
+    L{end+1} = '    save_properties_mat(out_folder)';
+    L{end+1} = '';
+    L{end+1} = 'print("Done. Point the GMC_Sorter GUI at:", HERE)';
     fprintf(fid, '%s\n', L{:});
     fclose(fid);
 end % local_write_driver
+
+% =========================================================================
+% MATLAB -> Python literal helpers for the generated driver
+% =========================================================================
+function s = local_py_bool(tf)
+    if tf, s = 'True'; else, s = 'False'; end
+end % local_py_bool
+
+function s = local_py_str(c)
+    s = ['"' strrep(c, '"', '\"') '"'];
+end % local_py_str
+
+function s = local_py_kwargs(nv)
+    % NV is a name/value cell; render it as Python keyword arguments.
+    parts = cell(1, numel(nv)/2);
+    for i = 1:2:numel(nv)
+        name = nv{i};
+        if isstring(name), name = char(name); end
+        if ~ischar(name)
+            error('ndi:fun:export:writeGmcSidecars:featureOptionName', ...
+                'featureOptions name %d is not a character vector.', (i+1)/2);
+        end
+        parts{(i+1)/2} = [name '=' local_py_value(nv{i+1})];
+    end
+    s = strjoin(parts, ', ');
+end % local_py_kwargs
+
+function s = local_py_value(v)
+    if islogical(v) && isscalar(v)
+        s = local_py_bool(v);
+    elseif ischar(v)
+        s = local_py_str(v);
+    elseif isstring(v) && isscalar(v)
+        s = local_py_str(char(v));
+    elseif isnumeric(v)
+        elems = arrayfun(@local_py_number, v(:).', 'UniformOutput', false);
+        if isscalar(v)
+            s = elems{1};
+        else
+            s = ['[' strjoin(elems, ', ') ']'];
+        end
+    else
+        error('ndi:fun:export:writeGmcSidecars:featureOptionValue', ...
+            'featureOptions values must be numeric, logical, or character; got %s.', class(v));
+    end
+end % local_py_value
+
+function s = local_py_number(x)
+    if isnan(x)
+        s = 'float("nan")';
+    elseif isinf(x)
+        if x>0, s = 'float("inf")'; else, s = 'float("-inf")'; end
+    else
+        s = num2str(x, '%.12g');
+    end
+end % local_py_number

--- a/tests/+ndi/+unittest/+fun/+export/gmcSorterWriteTest.m
+++ b/tests/+ndi/+unittest/+fun/+export/gmcSorterWriteTest.m
@@ -13,6 +13,10 @@ classdef gmcSorterWriteTest < matlab.unittest.TestCase
     %   * The file sizes yield the same n_saved_chans / n_time_samples /
     %     sample_rate that parse_dat_t_s_metadata computes.
     %   * The channel map (channel_positions.csv) is [x y] in channel order.
+    %
+    % It also covers the GMC_Sorter Version 4 sidecars: channel_info.csv (the
+    % per-shank ch_order/ch_map source), the kcoords/connected additions to
+    % channel_map.mat, and the generated run_gmc_extract.py driver.
 
     properties
         OutDir
@@ -123,6 +127,100 @@ classdef gmcSorterWriteTest < matlab.unittest.TestCase
             % driver + metadata exist
             testCase.verifyTrue(isfile(fullfile(testCase.OutDir,'run_gmc_extract.py')));
             testCase.verifyTrue(isfile(fullfile(testCase.OutDir,'RawData.metadata')));
+        end
+
+        function testChannelInfoDefaults(testCase)
+            % channel_info.csv: 0-based channel, [x y], shank, connected.
+            % With no shankIndex/connected given, everything is one connected shank.
+            [x, t, pos, fs] = testCase.basicData();
+            ndi.fun.export.gmcSorterWrite(testCase.OutDir, x, t, pos, ...
+                'baseName','RawData','sampleRate',fs,'verbose',0);
+
+            info = readmatrix(fullfile(testCase.OutDir,'channel_info.csv'), ...
+                'NumHeaderLines', 1);
+            nCh = size(pos,1);
+            testCase.verifyEqual(size(info), [nCh 5], 'channel_info.csv shape');
+            testCase.verifyEqual(info(:,1), (0:nCh-1).', '0-based channel index');
+            testCase.verifyEqual(info(:,2:3), pos, 'AbsTol', 1e-6);
+            testCase.verifyEqual(info(:,4), ones(nCh,1), 'default: one shank');
+            testCase.verifyEqual(info(:,5), ones(nCh,1), 'default: all connected');
+        end
+
+        function testChannelInfoShanksAndConnected(testCase)
+            % A 2-shank probe with one dead channel round-trips into the sidecars.
+            [x, t, pos, fs] = testCase.basicData();
+            shank = [1;1;2;2];
+            conn  = [true;false;true;true];
+            ndi.fun.export.gmcSorterWrite(testCase.OutDir, x, t, pos, ...
+                'baseName','RawData','sampleRate',fs,'verbose',0, ...
+                'shankIndex',shank,'connected',conn);
+
+            info = readmatrix(fullfile(testCase.OutDir,'channel_info.csv'), ...
+                'NumHeaderLines', 1);
+            testCase.verifyEqual(info(:,4), shank, 'shank ids');
+            testCase.verifyEqual(logical(info(:,5)), conn, 'connected flags');
+
+            % channel_map.mat carries the same as kcoords / connected
+            m = load(fullfile(testCase.OutDir,'channel_map.mat'));
+            testCase.verifyEqual(m.kcoords(:), shank, 'kcoords');
+            testCase.verifyEqual(logical(m.connected(:)), conn, 'connected');
+        end
+
+        function testShankIndexLengthMismatchErrors(testCase)
+            [x, t, pos, fs] = testCase.basicData();
+            testCase.verifyError(@() ndi.fun.export.gmcSorterWrite( ...
+                testCase.OutDir, x, t, pos, 'sampleRate',fs,'verbose',0, ...
+                'shankIndex',[1;1;2]), ...
+                'ndi:fun:export:writeGmcSidecars:shankIndex');
+        end
+
+        function testDriverUsesVersion4Api(testCase)
+            % The generated driver must drive GMC_Sorter Version 4:
+            % one extract_spike_features(..., ch_order=...) pass per shank,
+            % then properties.mat.
+            [x, t, pos, fs] = testCase.basicData();
+            ndi.fun.export.gmcSorterWrite(testCase.OutDir, x, t, pos, ...
+                'baseName','RawData','sampleRate',fs,'verbose',0, ...
+                'shankIndex',[1;1;2;2], ...
+                'featureOptions',{'refr_space',150,'noise_space',NaN});
+
+            drv = fileread(fullfile(testCase.OutDir,'run_gmc_extract.py'));
+            testCase.verifyNotEmpty(strfind(drv,'from sp_feature_ext import extract_spike_features'), ...
+                'imports the Version 4 extractor');
+            testCase.verifyNotEmpty(strfind(drv,'ch_order=sh["ch_order"]'), ...
+                'passes ch_order (the Version 4 addition)');
+            testCase.verifyNotEmpty(strfind(drv,'channel_info.csv'), ...
+                'reads the per-shank channel table');
+            testCase.verifyNotEmpty(strfind(drv,'save_properties_mat(out_folder)'), ...
+                'writes properties.mat as main.py does');
+            % featureOptions become Python keyword arguments
+            testCase.verifyNotEmpty(strfind(drv, ...
+                'EXTRACT_KWARGS = dict(refr_space=150, noise_space=float("nan"))'), ...
+                'featureOptions render as Python kwargs, NaN included');
+            % no probe_mappings import unless gmcProbeName was asked for
+            testCase.verifyEmpty(strfind(drv,'from probe_mappings import'), ...
+                'probe_mappings imported only when gmcProbeName is set');
+        end
+
+        function testDriverProbeMappingsMode(testCase)
+            [x, t, pos, fs] = testCase.basicData();
+            ndi.fun.export.gmcSorterWrite(testCase.OutDir, x, t, pos, ...
+                'baseName','RawData','sampleRate',fs,'verbose',0, ...
+                'gmcProbeName','KN_UCLA_64M');
+
+            drv = fileread(fullfile(testCase.OutDir,'run_gmc_extract.py'));
+            testCase.verifyNotEmpty(strfind(drv,'from probe_mappings import get_probe_map'), ...
+                'imports GMC_Sorter''s probe table');
+            testCase.verifyNotEmpty(strfind(drv,'PROBE_NAME = "KN_UCLA_64M"'), ...
+                'names the probe');
+        end
+
+        function testFeatureOptionsMustBePairs(testCase)
+            [x, t, pos, fs] = testCase.basicData();
+            testCase.verifyError(@() ndi.fun.export.gmcSorterWrite( ...
+                testCase.OutDir, x, t, pos, 'sampleRate',fs,'verbose',0, ...
+                'featureOptions',{'refr_space'}), ...
+                'ndi:fun:export:writeGmcSidecars:featureOptions');
         end
 
         function testMultiplierAndSaturation(testCase)


### PR DESCRIPTION
## Summary
This PR updates the GMC_Sorter export functionality to target GMC_Sorter Version 4, which introduces a multi-shank sorting architecture. The generated driver now runs one `extract_spike_features` pass per probe shank (using the new `ch_order` parameter) rather than processing all channels in a single pass.

## Key Changes

- **Multi-shank support**: Added `shankIndex` and `connected` parameters to specify which shank each channel belongs to and whether it has an electrode site. The generated driver groups channels by shank and runs separate extraction passes.

- **New channel_info.csv sidecar**: Writes a CSV file containing per-channel metadata (0-based index, [x,y] positions, shank ID, connected status) that the driver uses to construct per-shank `ch_order` and `ch_map` pairs.

- **Enhanced channel_map.mat**: Now includes `kcoords` (shank IDs) and `connected` flags alongside the existing `xcoords`, `ycoords`, and `ch_map`.

- **Version 4 driver generation**: The generated `run_gmc_extract.py` now:
  - Reads `channel_info.csv` to determine shank groupings
  - Runs one `extract_spike_features(..., ch_order=...)` call per shank
  - Optionally uses GMC_Sorter's built-in probe mappings via `gmcProbeName`
  - Supports custom feature extraction options via `featureOptions`
  - Concatenates per-shank results into `properties.mat` (matching GMC_Sorter's main.py behavior)
  - Organizes multi-shank output into `Sh0/`, `Sh1/`, etc. subdirectories

- **Geometry handling**: Updated `local_channel_geometry()` to extract and propagate shank and connectivity information from probe geometry documents (via `toKilosortMap`), with explicit parameter overrides.

- **Python code generation helpers**: Added utility functions (`local_py_bool`, `local_py_str`, `local_py_kwargs`, `local_py_value`, `local_py_number`) to properly render MATLAB values as Python literals in the generated driver.

- **Comprehensive test coverage**: Added unit tests for channel info CSV generation, shank/connectivity round-tripping, Version 4 API usage, probe mappings mode, and feature options validation.

## Notable Implementation Details

- Channels are sorted tip-to-base (ascending y) within each shank by default (`sortByDepth` option), matching GMC_Sorter's probe_mappings convention.
- Unconnected channels are exported to the data files but excluded from `ch_order`, so GMC_Sorter never attempts to sort them.
- The driver reads the actual exported time interval from the timestamps file rather than assuming t=0 start.
- Feature extraction keyword arguments (e.g., `refr_space`, `wvf_space`, `noise_space`) can be passed through and are properly rendered as Python literals, including special handling for NaN and infinity.

https://claude.ai/code/session_012LwizZUb5WmRebJ2XrDGqL