### PR TITLE
Add forceUpdate option to lab and rayolab setup functions

### DIFF
--- a/src/ndi/+ndi/+setup/lab.m
+++ b/src/ndi/+ndi/+setup/lab.m
@@ -1,7 +1,8 @@
-function S = lab(labName, ref, dirname)
+function S = lab(labName, ref, dirname, options)
 %NDI.SETUP.LAB Initialize an NDI session directory with lab-specific devices
 %
 %   S = NDI.SETUP.LAB(LABNAME, REF, DIRNAME)
+%   S = NDI.SETUP.LAB(..., 'forceUpdate', TF)
 %
 %   Initializes an NDI session directory object (ndi.session.dir) for the
 %   specified directory DIRNAME. It associates the session with a reference
@@ -12,7 +13,8 @@ function S = lab(labName, ref, dirname)
 %   'ndi_common/daq_systems/<labName>' directory, located under the NDI
 %   common path (typically found via `ndi.path.commonpath`). If DAQ system
 %   devices corresponding to LABNAME already exist in the session directory,
-%   they are not added again.
+%   they are not added again, unless 'forceUpdate' is true, in which case any
+%   existing DAQ systems with these names are removed and re-created.
 %
 %   Inputs:
 %     labName - The name of the lab setup configuration. This determines
@@ -24,6 +26,14 @@ function S = lab(labName, ref, dirname)
 %     dirname - The full path to the directory where the NDI session data
 %               will be stored. This directory must exist. Must be a
 %               character vector or string scalar representing a valid folder path.
+%
+%   Name-value arguments:
+%     forceUpdate - A logical scalar (default false). If true, any DAQ system
+%               belonging to LABNAME that already exists in the session is
+%               removed and re-installed from the current definition in
+%               ndi_common/daq_systems/<labName>. This is useful when the DAQ
+%               system definitions have been updated. If false (the default),
+%               existing DAQ systems are left untouched.
 %
 %   Outputs:
 %     S       - An ndi.session.dir object representing the initialized
@@ -42,6 +52,10 @@ function S = lab(labName, ref, dirname)
 %       % Initialize the session with lab-specific devices
 %       mySession = ndi.setup.lab(labId, sessionRef, sessionPath);
 %
+%       % Re-install the lab's DAQ systems, discarding any existing ones
+%       mySession = ndi.setup.lab(labId, sessionRef, sessionPath, ...
+%           'forceUpdate', true);
+%
 %   See also: ndi.session.dir, ndi.setup.daq.addDaqSystems,
 %             ndi.setup.sync.addSyncRules, ndi.path.commonpath
 
@@ -50,6 +64,7 @@ function S = lab(labName, ref, dirname)
         labName (1,:) {mustBeTextScalar} % Lab name must be char vector or string scalar
         ref (1,:) {mustBeTextScalar}     % Reference must be char vector or string scalar
         dirname (1,:) {mustBeFolder, mustBeTextScalar} % Directory must exist and be text
+        options.forceUpdate (1,1) logical = false % Remove and re-create existing DAQ systems
     end
 
     % Create the session directory object
@@ -57,7 +72,9 @@ function S = lab(labName, ref, dirname)
 
     % Add the DAQ systems associated with the specified lab name
     % This function typically finds definitions in ndi.path.commonpath/daq_systems/labName
-    S = ndi.setup.daq.addDaqSystems(S, labName);
+    % If options.forceUpdate is true, existing DAQ systems with these names are
+    % removed from the session before being re-created.
+    S = ndi.setup.daq.addDaqSystems(S, labName, options.forceUpdate);
 
     % by default, include syncrule for same file names
     nsf = ndi.time.syncrule.filematch(struct('number_fullpath_matches',2));

--- a/src/ndi/+ndi/+setup/rayolab.m
+++ b/src/ndi/+ndi/+setup/rayolab.m
@@ -1,12 +1,15 @@
-function S = rayolab(ref, dirname)
+function S = rayolab(ref, dirname, options)
 %NDI.SETUP.RAYOLAB Initialize an NDI session directory with RayoLab devices.
 %
 %   S = NDI.SETUP.RAYOLAB(REF, DIRNAME)
+%   S = NDI.SETUP.RAYOLAB(..., 'forceUpdate', TF)
 %
 %   Initializes an ndi.session.dir object for the directory DIRNAME with
 %   the standard RayoLab DAQ system configurations, as defined in
 %   "ndi_common/daq_systems/rayolab". If the devices are already added
-%   to the session, they are not re-created.
+%   to the session, they are not re-created, unless 'forceUpdate' is true,
+%   in which case any existing RayoLab DAQ systems are removed and
+%   re-installed from their current definitions.
 %
 %   The RayoLab setup currently includes the rayo_intanSeries device,
 %   which uses ndi.file.navigator.rhd_series to group recordings by
@@ -19,12 +22,23 @@ function S = rayolab(ref, dirname)
 %     ref     - Reference identifier for the session (char or string).
 %     dirname - Full path to the existing session directory.
 %
+%   Name-value arguments:
+%     forceUpdate - A logical scalar (default false). If true, existing
+%               RayoLab DAQ systems are removed from the session and
+%               re-created from the current definitions in
+%               ndi_common/daq_systems/rayolab. Useful when the DAQ system
+%               definitions have been updated.
+%
 %   Output:
 %     S       - The ndi.session.dir object with RayoLab DAQ systems
 %               added.
 %
 %   Example:
 %       S = ndi.setup.rayolab('exp001', '/path/to/session');
+%
+%       % Re-install the RayoLab DAQ systems, discarding any existing ones
+%       S = ndi.setup.rayolab('exp001', '/path/to/session', ...
+%           'forceUpdate', true);
 %
 %   See also: ndi.setup.lab, ndi.session.dir,
 %             ndi.file.navigator.rhd_series,
@@ -33,7 +47,9 @@ function S = rayolab(ref, dirname)
     arguments
         ref (1,:) {mustBeTextScalar}
         dirname (1,:) {mustBeFolder, mustBeTextScalar}
+        options.forceUpdate (1,1) logical = false
     end
 
-    S = ndi.setup.lab('rayolab', ref, dirname);
+    S = ndi.setup.lab('rayolab', ref, dirname, ...
+        'forceUpdate', options.forceUpdate);
 end


### PR DESCRIPTION
## Summary
This PR adds a `forceUpdate` optional parameter to the `ndi.setup.lab` and `ndi.setup.rayolab` functions, allowing users to force re-installation of DAQ systems even if they already exist in the session.

## Key Changes
- **ndi.setup.lab**: Added `options` parameter with `forceUpdate` name-value argument (default: false)
  - When `forceUpdate` is true, existing DAQ systems with matching names are removed and re-created from current definitions
  - Updated function signature and documentation to reflect the new capability
  - Passes the `forceUpdate` flag to `ndi.setup.daq.addDaqSystems`

- **ndi.setup.rayolab**: Added `options` parameter with `forceUpdate` name-value argument (default: false)
  - Forwards the `forceUpdate` option to the underlying `ndi.setup.lab` call
  - Updated documentation with examples showing the new usage pattern

## Implementation Details
- Both functions use MATLAB's `arguments` block for parameter validation
- The `forceUpdate` parameter is a logical scalar with a default value of `false` to maintain backward compatibility
- Documentation includes new examples demonstrating the `forceUpdate` usage
- The implementation allows users to refresh DAQ system definitions without manually removing and re-adding them

https://claude.ai/code/session_015rnwVT6vJL8AbSDwJ4TTdM