### PR TITLE
Stop mock elements from colliding on a reused reference number

### DIFF
--- a/src/ndi/+ndi/+mock/+fun/subject_stimulator_neuron.m
+++ b/src/ndi/+ndi/+mock/+fun/subject_stimulator_neuron.m
@@ -7,8 +7,10 @@ function [output] = subject_stimulator_neuron(ndi_session_obj)
     % and mock spiking neuron with responses as specified.
     % OUTPUT is a structure with fields discussed below.
     %
-    % OUTPUT.refNum: a random reference number, used in the name and reference of the
-    % mock subject and the mock stimulator and mock spike object.
+    % OUTPUT.refNum: a reference number, used in the name and reference of the
+    % mock subject and the mock stimulator and mock spike object. It is drawn at
+    % random and checked against the session, so that repeated calls on one
+    % session never reuse a number. See the note at pickFreeReference below.
     %
     % OUTPUT.mock_subject: Attempts to find or create a mock subject called
     %    'mockREFNUM@nosuchlab.org'. An NDI_document is returned in field mock_subject.
@@ -29,7 +31,8 @@ function [output] = subject_stimulator_neuron(ndi_session_obj)
 
     % Step 0:
 
-    refNum = 20000+randi(1000); % ndi.fun.pseudorandomint(); -- this produces too large of numbers
+    refNum = pickFreeReference(S);
+    output.refNum = refNum; % documented above, but never returned until now
 
     % Step 1: set up mock subject
 
@@ -109,3 +112,81 @@ function [output] = subject_stimulator_neuron(ndi_session_obj)
     if add_blank
         stim_pres_struct.stimuli(end+1,1) = struct('parameters',struct('isblank',1));
     end
+
+end % subject_stimulator_neuron()
+
+function refNum = pickFreeReference(S)
+    % PICKFREEREFERENCE - a mock reference number not already used in this session
+    %
+    % An ndi.element is identified by its name, type and reference, so two mock
+    % elements drawn with the same reference are one element. The second call
+    % then adds a second epoch named 'mockepoch' to it, and reading that epoch
+    % fails: epochtableentry returns two entries and the caller indexes it as
+    % one. This is what happens when several mocks are made in a session
+    % without clearing in between, as when a calculator regenerates all of its
+    % stored self-test expectations in one go.
+    %
+    % The number was previously drawn from a span of 1000 with no check, which
+    % collides about one time in five over 22 draws. Drawing is still random
+    % rather than sequential, so that routines running in parallel on separate
+    % sessions do not march in step; the check is what makes it safe.
+    %
+    % The reference field of an element document is an integer bounded by
+    % element_schema.json at 100000, so the span stays well inside that.
+
+    arguments
+        S (1,1) ndi.session
+    end
+
+    referenceMin = 20000;
+    referenceSpan = 60000;
+    maxAttempts = 100;
+
+    for attempt = 1:maxAttempts
+        candidate = referenceMin + randi(referenceSpan);
+        if ~mockReferenceInUse(S, candidate)
+            refNum = candidate;
+            return;
+        end
+    end
+
+    error('ndi:mock:subject_stimulator_neuron:noFreeReference',...
+        ['Could not find an unused mock reference number in %d attempts, over the range '...
+        '%d to %d. The session appears to be full of mock documents; '...
+        'ndi.mock.fun.clear removes them.'],...
+        maxAttempts, referenceMin+1, referenceMin+referenceSpan);
+
+end % pickFreeReference()
+
+function b = mockReferenceInUse(S, refNum)
+    % MOCKREFERENCEINUSE - does this session already hold a mock at this reference?
+    %
+    % Checks the subject as well as the two elements, because the subject name
+    % carries the number too and a leftover subject would produce a second mock
+    % subject with the same name.
+
+    arguments
+        S (1,1) ndi.session
+        refNum (1,1) double
+    end
+
+    b = true;
+
+    q = ndi.query('subject.local_identifier','exact_string',...
+        ['mock' int2str(refNum) '@nosuchlab.org'],'');
+    if ~isempty(S.database_search(q))
+        return;
+    end
+
+    elementNames = {'mock stimulator','mock spikes'};
+    for i = 1:numel(elementNames)
+        q = ndi.query('element.name','exact_string',elementNames{i},'') & ...
+            ndi.query('element.reference','exact_number',refNum,'');
+        if ~isempty(S.database_search(q))
+            return;
+        end
+    end
+
+    b = false;
+
+end % mockReferenceInUse()


### PR DESCRIPTION
## The bug

`ndi.mock.fun.subject_stimulator_neuron` drew its reference number as

```matlab
refNum = 20000+randi(1000);
```

unseeded, unchecked, and from a span of 1000.

An `ndi.element` is identified by name, type and reference, so a repeated draw does not create a second element — it finds the first one. `addepoch` then gives that element a *second* epoch named `mockepoch`, and any later read of it fails in `ndi.element.timeseries/readtimeseries:41`:

```matlab
et_entry.epoch_clock{1}
```

because `epochtableentry` now returns two entries and that line indexes it as one:

> Intermediate dot '.' indexing produced a comma-separated list with 2 values, but it must produce a single value when followed by subsequent indexing operations.

## Why it has gone unnoticed

Over 22 draws from a span of 1000 the collision probability is about **21%** — roughly one run in five. So it surfaces as an intermittent failure whose frequency depends on how many mocks a session has accumulated.

CI never sees it: each calculator self-test creates one mock, so it draws once.

It bites when a calculator regenerates all of its stored self-test expectations in one session — which is exactly when a maintainer is least able to tell it apart from a real change in the data. That is how it was found, regenerating the `spatial_frequency_tuning` and `speed_tuning` expectations in NDIcalc-vis-matlab.

## The fix

`pickFreeReference` checks each candidate against the session before using it:

- the mock subject, whose local identifier carries the number
- both mock elements at that reference

and draws again if it is taken, up to 100 times before raising an error that names `ndi.mock.fun.clear` as the remedy.

The span widens from 1000 to 60000, which makes a first-draw collision rare — but **the check, not the span, is what makes it correct**.

Two things deliberately kept:

- **Random, not sequential.** Routines running in parallel against separate sessions should not march in step.
- **Well inside 100000.** `element_schema.json` bounds the integer `reference` field at 100000, which is why the span is not widened further.

## Incidental

- `subject_stimulator_neuron` gained a terminating `end`, required now that the file defines local functions.
- `output.refNum` is now set. The header has documented that field all along without it ever being returned.

## Not verified

No MATLAB in the authoring session, per `AGENTS.md` — inspection only. The self-tests that exercise this path are the natural first check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KcnrjoBSphEijFucc53noG

---
_Generated by [Claude Code](https://claude.ai/code/session_01KcnrjoBSphEijFucc53noG)_