### PR TITLE
Seed the mock trial-to-trial variability

### DIFF
--- a/src/ndi/+ndi/+calc/+stimulus/tuningcurve.m
+++ b/src/ndi/+ndi/+calc/+stimulus/tuningcurve.m
@@ -473,8 +473,10 @@ classdef tuningcurve < ndi.calculator
                 reps = 5; % Number of repetitions
 
                 % Use the mock utility to generate documents
+                 % Seeded by test index; see the note in ndi.calc.tuning_fit.
                 docs_here = ndi.mock.fun.stimulus_response(ndi_calculator_obj.session, ...
-                    param_struct, independent_variables, X, R, noise, reps);
+                    param_struct, independent_variables, X, R, noise, reps, ...
+                    'RandomSeed', i);
 
                 % Extract the relevant input documents (subject, stimulator, spikes, stim_pres, control_stim, stim_response)
                 % ndi.mock.fun.stimulus_response returns:

--- a/src/ndi/+ndi/+calc/tuning_fit.m
+++ b/src/ndi/+ndi/+calc/tuning_fit.m
@@ -78,8 +78,14 @@ classdef (Abstract) tuning_fit < ndi.calculator
                                 error(['Unknown scope ' scope '.']);
                         end % switch
 
+                         % Seed by test index, so each self-test keeps its own
+                         % noise realisation and repeated runs reproduce it. One
+                         % seed for all of them would give every test the same
+                         % draw, which would weaken the requireDistinct check in
+                         % ndi.mock.ctest/verifyTestResults.
                         docs{i} = ndi.mock.fun.stimulus_response(obj.session,...
-                            param_struct, independent_variable, x, r, noise, reps);
+                            param_struct, independent_variable, x, r, noise, reps,...
+                            'RandomSeed', i);
 
                         calcparameters = obj.default_search_for_input_parameters();
 

--- a/src/ndi/+ndi/+mock/+fun/stimulus_presentation.m
+++ b/src/ndi/+ndi/+mock/+fun/stimulus_presentation.m
@@ -65,6 +65,18 @@ function [stim_pres_doc,spiketimes] = stimulus_presentation(S, stimulus_element_
         options.interstimulus_interval (1,1) double = 5
         options.stim_duration_min (1,1) double = 0.2
         options.epochid (1,:) char = 'mockepoch'
+        options.RandomSeed = 0
+    end
+
+     % Draw the trial-to-trial variability from a private, seeded stream. It
+     % came from the global one, unseeded, so the same mock inputs produced
+     % different responses on every call and no stored expectation computed from
+     % them could be reproduced. Empty selects the global stream, for a caller
+     % who wants a fresh draw each time.
+    if isempty(options.RandomSeed)
+        noiseStream = RandStream.getGlobalStream();
+    else
+        noiseStream = RandStream('mt19937ar','Seed',options.RandomSeed);
     end
 
     stim_duration = options.stim_duration;
@@ -103,7 +115,7 @@ function [stim_pres_doc,spiketimes] = stimulus_presentation(S, stimulus_element_
 
         % now see how many spikes to fire for this stimulus
         stimid = stim_pres_struct.presentation_order(i);
-        R_here = R(stimid) + noise * randn * R(stimid);
+        R_here = R(stimid) + noise * randn(noiseStream) * R(stimid);
         if ~isnan(R_here) & (R_here>0)
             n_spikes_mean = R_here * stim_duration;
             n_spikes_floor = floor( n_spikes_mean );

--- a/src/ndi/+ndi/+mock/+fun/stimulus_response.m
+++ b/src/ndi/+ndi/+mock/+fun/stimulus_response.m
@@ -59,6 +59,7 @@ function [docs] = stimulus_response(S, parameter_struct, independent_variables, 
         options.interstimulus_interval (1,1) double = 3
         options.stim_duration_min (1,1) double = 0.2
         options.epochid (1,:) char = 'mockepoch'
+        options.RandomSeed = 0
     end
 
     mock_output = ndi.mock.fun.subject_stimulator_neuron(S);


### PR DESCRIPTION
## The bug

`ndi.mock.fun.stimulus_presentation` drew the noise it adds to each mock response from the global random stream, unseeded:

```matlab
R_here = R(stimid) + noise * randn * R(stimid);
```

The same mock inputs therefore gave different responses on every call, and no stored expectation computed from them could be reproduced.

## What it looks like when it bites

The same commit, the same stored expectations, run twice, disagreeing about **which tests fail and on which fields**:

| where | failing self-tests | out of tolerance |
|---|---|---|
| CI | spatial 12 | `significance.visual_response_anova_p`, `across_stimuli_anova_p` |
| a maintainer's Mac | spatial 12, 16, 18 | `fit_dog.Pref`, `fit_dog.H50`, `fit_dog.R2`, `abs.fit_dog.fit`, `abs.fit_dog.R2`, `fit_spline.fit`, `abs.fit_spline.fit` |

`fit_spline` is the giveaway. A spline **interpolates** its inputs, so there is no fitting freedom in it: a spline fit that moves proves the *inputs* moved. There is no unseeded randomness anywhere in the frequency analysis code, so the mock data is the only candidate.

## The fix

A private seeded stream, leaving the caller's own random numbers undisturbed. Passing an empty `RandomSeed` restores a fresh draw for anyone who wants one.

**The seed varies with the self-test index** rather than being one constant for the battery, so each test keeps its own noise realisation. A single seed would hand every test the identical draw, which would weaken the `requireDistinct` check in `ndi.mock.ctest/verifyTestResults` — a check that exists precisely to establish that different self-tests give different answers. Both call sites (`ndi.calc.tuning_fit`, `ndi.calc.stimulus.tuningcurve`) pass `'RandomSeed', i`.

## Context

This is the last of the unseeded sources behind the reviewer reports that prompted the R1.37/R1.38 work in NDIcalc-vis-matlab. Those fixed one calculator's own mock generator and the speed fits. This one sits upstream of **all five `tuning_fit` calculators and `ndi.calc.stimulus.tuningcurve`**, and it went unnoticed because nothing verified those comparisons until this week — the self-tests computed the verdict and discarded it.

## Expect stored expectations to need regenerating

The realisation each test now sees is a specific one, and differs from whichever unseeded draw produced the expectations on file.

- **Here:** `ndi.calc.stimulus.tuningcurve`, whose `testCalcTuningCurve` runs with `requireDistinct`. This PR may turn that red.
- **Downstream:** the five `tuning_fit` calculators in NDIcalc-vis-matlab — 64 expectations between them.

Regenerating is a deliberate act and needs MATLAB, so this PR does not attempt it. It also unblocks VH-Lab/NDIcalc-vis-matlab#98, which is red on exactly this.

## Not verified

No MATLAB in the authoring session, per `AGENTS.md` — inspection only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KcnrjoBSphEijFucc53noG

---
_Generated by [Claude Code](https://claude.ai/code/session_01KcnrjoBSphEijFucc53noG)_