### PR TITLE
Draw the mock trial-to-trial noise fresh on every run

### DIFF
--- a/src/ndi/+ndi/+calc/+stimulus/tuningcurve.m
+++ b/src/ndi/+ndi/+calc/+stimulus/tuningcurve.m
@@ -473,10 +473,10 @@ classdef tuningcurve < ndi.calculator
                 reps = 5; % Number of repetitions
 
                 % Use the mock utility to generate documents
-                 % Seeded by test index; see the note in ndi.calc.tuning_fit.
+                 % A fresh draw on every run; see the note in ndi.calc.tuning_fit.
                 docs_here = ndi.mock.fun.stimulus_response(ndi_calculator_obj.session, ...
                     param_struct, independent_variables, X, R, noise, reps, ...
-                    'RandomSeed', i);
+                    'RandomSeed', 'shuffle');
 
                 % Extract the relevant input documents (subject, stimulator, spikes, stim_pres, control_stim, stim_response)
                 % ndi.mock.fun.stimulus_response returns:

--- a/src/ndi/+ndi/+calc/tuning_fit.m
+++ b/src/ndi/+ndi/+calc/tuning_fit.m
@@ -78,14 +78,14 @@ classdef (Abstract) tuning_fit < ndi.calculator
                                 error(['Unknown scope ' scope '.']);
                         end % switch
 
-                         % Seed by test index, so each self-test keeps its own
-                         % noise realisation and repeated runs reproduce it. One
-                         % seed for all of them would give every test the same
-                         % draw, which would weaken the requireDistinct check in
-                         % ndi.mock.ctest/verifyTestResults.
+                         % Draw a fresh noise realization on every run. Pinning
+                         % it made a self-test reproduce one stored draw rather
+                         % than show that the calculator recovers its answer from
+                         % data it has not seen, and the two are indistinguishable
+                         % from outside. Pass a seed to reproduce a run by hand.
                         docs{i} = ndi.mock.fun.stimulus_response(obj.session,...
                             param_struct, independent_variable, x, r, noise, reps,...
-                            'RandomSeed', i);
+                            'RandomSeed', 'shuffle');
 
                         calcparameters = obj.default_search_for_input_parameters();
 

--- a/src/ndi/+ndi/+mock/+fun/stimulus_presentation.m
+++ b/src/ndi/+ndi/+mock/+fun/stimulus_presentation.m
@@ -65,14 +65,15 @@ function [stim_pres_doc,spiketimes] = stimulus_presentation(S, stimulus_element_
         options.interstimulus_interval (1,1) double = 5
         options.stim_duration_min (1,1) double = 0.2
         options.epochid (1,:) char = 'mockepoch'
-        options.RandomSeed = 0
+        options.RandomSeed = 'shuffle'
     end
 
-     % Draw the trial-to-trial variability from a private, seeded stream. It
-     % came from the global one, unseeded, so the same mock inputs produced
-     % different responses on every call and no stored expectation computed from
-     % them could be reproduced. Empty selects the global stream, for a caller
-     % who wants a fresh draw each time.
+     % Draw the trial-to-trial variability from a private stream, so that
+     % generating a mock does not disturb the caller's own random numbers. By
+     % default the stream is not pinned: each call draws fresh, so a self-test
+     % that passes has recovered its answer from data it has not seen before.
+     % Pass a non-negative integer to reproduce a particular call's responses,
+     % or empty to draw from the global stream.
     if isempty(options.RandomSeed)
         noiseStream = RandStream.getGlobalStream();
     else

--- a/src/ndi/+ndi/+mock/+fun/stimulus_response.m
+++ b/src/ndi/+ndi/+mock/+fun/stimulus_response.m
@@ -59,7 +59,7 @@ function [docs] = stimulus_response(S, parameter_struct, independent_variables, 
         options.interstimulus_interval (1,1) double = 3
         options.stim_duration_min (1,1) double = 0.2
         options.epochid (1,:) char = 'mockepoch'
-        options.RandomSeed = 0
+        options.RandomSeed = 'shuffle'
     end
 
     mock_output = ndi.mock.fun.subject_stimulator_neuron(S);


### PR DESCRIPTION
Reverses the seeding added in 52d6726, which pinned the mock trial-to-trial noise so that a stored expectation could be reproduced.

That commit fixed a real problem — the same code and the same expectations disagreeing between runs about which self-tests failed. But it bought reproducibility at the cost of what the self-test demonstrates. A test compared against one pinned draw shows only that the calculation is deterministic. It cannot be told apart, from outside, from a test showing that the calculator recovers its answer from data it has not seen — and the weaker reading is the one a skeptic reaches for. This came up in review of the NDIcalc-vis-matlab calculators paper, where "the fits only pass because of the seed" is exactly the objection the seeding invites.

## Why the seed isn't needed for the comparisons to hold

- At `highSNR` the noise is `0.001` of each response over five reps. The mean of a fresh draw differs from a stored one by roughly `0.0006` of the response, against tolerances declared at `0.2` and above in the downstream calculators — a margin of order 200×.
- The comparisons that actually went out of tolerance when this was unseeded were the ANOVA p-values, and those are now compared by the decision they support rather than their digits (`pValueConsistent`), which is robust to draw-to-draw variation.
- Separately, a replication of the `speed_tuning` fit outside MATLAB found the multi-start search reaching the same optimum to within `1e-9` across 24 different start seeds, against a `0.2` tolerance on the speed tuning index, and recovering every parameter to better than 1% across 120 runs with the noise varying. The companion change unseeding those fit start points is in NDIcalc-vis-matlab.

## Changes

`RandomSeed` now defaults to `'shuffle'` throughout — a private stream, so generating a mock still leaves the caller's own random numbers undisturbed, but a fresh draw on every call. Passing a non-negative integer pins it for reproducing a particular run by hand; empty still selects the global stream.

- `src/ndi/+ndi/+mock/+fun/stimulus_presentation.m` — default and the comment explaining it
- `src/ndi/+ndi/+mock/+fun/stimulus_response.m` — matching default on the forwarding wrapper
- `src/ndi/+ndi/+calc/tuning_fit.m` — the per-test-index seed for the five `tuning_fit` calculators
- `src/ndi/+ndi/+calc/+stimulus/tuningcurve.m` — the same call site on the tuningcurve path

## Notes for review

- **`ndi.calc.stimulus.tuningcurve` at `highSNR` is unaffected.** That scope sets `noise = 0`, and the private stream is drawn from only for the `noise * randn * R` term, so the seed was already a no-op there. Only its `lowSNR` scope (noise `0.2`) sees any change.
- **`requireDistinct` is unaffected.** It asks that one self-test's answer not match another's expectation. The self-tests differ in their mock parameters, not merely in their noise — at `0.001` the noise could not be what tells them apart.
- **`'shuffle'` seeds from the clock**, so calls in very quick succession can land on the same seed. Each self-test iteration builds and stores documents, so they should be well separated in practice.

## Testing

Not verified — no MATLAB in the authoring session, per `AGENTS.md`. Static changes only, submitted for review by someone who can run MATLAB.

**The stored expectations will need regenerating**, here and in NDIcalc-vis-matlab, since they hold the seeded values. That is a deliberate act and this PR does not attempt it. Worth running the suite several times rather than once when regenerating, to confirm the margins above hold in practice.

---
_Generated by [Claude Code](https://claude.ai/code/session_013kmFxco9Aqn8i3yLf7A6bJ)_