### PR TITLE
Fail the whatVaries divergence audit, and retire the entry it caught

### DIFF
--- a/tests/+ndi/+symmetry/+fun/cases.m
+++ b/tests/+ndi/+symmetry/+fun/cases.m
@@ -801,7 +801,9 @@ classdef cases
             defs(k).expectedVariesValues = {'[0, 90]'};
             defs(k).expectedConstant = {'color'};
             defs(k).expectedConstantValues = {'[''r'', ''g'', ''b'']'};
-            defs(k).divergenceExpected = true;
+            % Was true on the prediction that MATLAB errors on a cell-valued
+            % '=='. Measured otherwise -- see knownDivergences.
+            defs(k).divergenceExpected = false;
             defs(k).mirrors = 'testCellValuedConstantParameter';
 
             k = k + 1;
@@ -895,26 +897,34 @@ classdef cases
 
         function names = knownDivergences()
             % KNOWNDIVERGENCES - whatVaries cases where MATLAB main and the
-            % Python port are believed to disagree TODAY.
+            % Python port are MEASURED to disagree TODAY.
             %
-            %   Both entries trace to one line: local_varyingFields in
+            %   The remaining entry traces to one line: local_varyingFields in
             %   src/ndi/+ndi/+fun/+stimulus/whatVaries.m compares with
             %   vlt.data.eqlen (which bottoms out in a bare '=='), while
             %   local_uniqueValues in the same file already uses isequaln and
             %   the Python port uses isequaln semantics throughout.
             %
-            %     cellValuedConstantParameter - '==' is undefined for two cell
-            %       arrays, so MATLAB is expected to ERROR where Python succeeds.
-            %     allNaNParameter - eqlen(NaN,NaN) is false, so MATLAB is
-            %       expected to report an all-NaN parameter as VARYING where
-            %       Python reports it CONSTANT.
+            %     allNaNParameter - eqlen(NaN,NaN) is false, so MATLAB reports
+            %       an all-NaN parameter as VARYING where Python reports it
+            %       CONSTANT.
             %
-            %   Both are SOURCE-READ predictions, not measurements. When this
-            %   suite is first run on a real MATLAB the readArtifacts test prints
-            %   whether each divergence is real; if one turns out to agree after
-            %   all, delete it here AND clear divergenceExpected in
-            %   whatVariesDefs so the case becomes a hard assertion again.
-            names = {'cellValuedConstantParameter', 'allNaNParameter'};
+            %   REMOVED, and why. cellValuedConstantParameter was listed here on
+            %   the source-read prediction that '==' is undefined for two cell
+            %   arrays and MATLAB would therefore ERROR. The first run on a real
+            %   MATLAB refuted it: eqlen({'r','g','b'},{'r','g','b'}) returns
+            %   true, MATLAB reports 'color' constant and 'angle' varying, and
+            %   the signature matches Python's exactly. The case is a hard
+            %   assertion again (divergenceExpected is false in whatVariesDefs).
+            %   Note the two predictions were independent -- allNaNParameter was
+            %   confirmed by the same run, so eqlen is still the reason for it.
+            %
+            %   A listed case that now agrees means the upstream fix landed:
+            %   delete it here AND clear divergenceExpected in whatVariesDefs so
+            %   the case becomes a hard assertion again. readArtifacts/fun/
+            %   whatVaries.testKnownDivergencesAreStillReal FAILS on a stale
+            %   entry rather than printing, so this cannot go unnoticed.
+            names = {'allNaNParameter'};
         end % knownDivergences
 
         function results = runWhatVariesCases()

--- a/tests/+ndi/+symmetry/+readArtifacts/+fun/whatVaries.m
+++ b/tests/+ndi/+symmetry/+readArtifacts/+fun/whatVaries.m
@@ -83,10 +83,22 @@ classdef whatVaries < matlab.unittest.TestCase
         end
 
         function testKnownDivergencesAreStillReal(testCase)
-            % Reports only -- never fails. A knownDivergences entry that now
-            % agrees across the two languages means the upstream fix has landed
-            % and the entry (plus the matching divergenceExpected flag in
-            % ndi.symmetry.fun.cases.whatVariesDefs) should be removed.
+            % FAILS on a stale entry. A knownDivergences entry that now agrees
+            % across the two languages means the upstream fix has landed, and
+            % the entry (plus the matching divergenceExpected flag in
+            % ndi.symmetry.fun.cases.whatVariesDefs) must be removed so the
+            % case becomes a hard assertion again.
+            %
+            % This used to report and never fail, which FUN_CASES_SCHEMA.md
+            % raised as an open question: a stale entry then landed as a line
+            % in the CI log rather than a red build, which is the same failure
+            % mode as a silently skipped test -- a suite going quietly green
+            % over the bug it exists to watch. Settled in favour of failing;
+            % the Python twin (audit_known_divergences) does the same.
+            %
+            % A case missing from either artifact still only reports: that is
+            % list drift, which the key-set check in testMatlabPythonSymmetry
+            % already fails on, and failing twice for one cause is noise.
             mlFile = ndi.symmetry.readArtifacts.fun.whatVaries.artifactFile('matlabArtifacts');
             pyFile = ndi.symmetry.readArtifacts.fun.whatVaries.artifactFile('pythonArtifacts');
             testCase.assumeTrue(isfile(mlFile) && isfile(pyFile), ...
@@ -98,6 +110,7 @@ classdef whatVaries < matlab.unittest.TestCase
                 ndi.symmetry.fun.cases.loadCases(pyFile));
 
             known = ndi.symmetry.fun.cases.knownDivergences();
+            stale = {};
             for i = 1:numel(known)
                 key = known{i};
                 if ~ml.isKey(key) || ~py.isKey(key)
@@ -108,6 +121,7 @@ classdef whatVaries < matlab.unittest.TestCase
                 sigML = ndi.symmetry.fun.cases.whatVariesSignature(ml(key));
                 sigPY = ndi.symmetry.fun.cases.whatVariesSignature(py(key));
                 if strcmp(sigML, sigPY)
+                    stale{end+1} = key; %#ok<AGROW>
                     fprintf(['knownDivergences entry ''%s'' now AGREES across languages. ' ...
                         'Remove it from ndi.symmetry.fun.cases.knownDivergences and clear ' ...
                         'divergenceExpected in whatVariesDefs so the case is asserted again.\n'], key);
@@ -116,6 +130,13 @@ classdef whatVaries < matlab.unittest.TestCase
                         key, sigML, sigPY);
                 end
             end
+
+            testCase.verifyEmpty(stale, sprintf( ...
+                ['%d knownDivergences entry/entries now agree across languages: %s. ' ...
+                 'The upstream fix has landed -- remove them from ' ...
+                 'ndi.symmetry.fun.cases.knownDivergences and clear the matching ' ...
+                 'divergenceExpected flags so the cases are asserted again.'], ...
+                numel(stale), strjoin(stale, ', ')));
         end
 
     end

--- a/tests/+ndi/+symmetry/FUN_CASES_SCHEMA.md
+++ b/tests/+ndi/+symmetry/FUN_CASES_SCHEMA.md
@@ -159,6 +159,19 @@ identifiers (`MATLAB:validators:mustBeTextScalar`) and Python exception names
 translation table instead of a behaviour check. Only the *fact* of an error
 (`status`) is symmetric.
 
+**A one-element `int list` arrives as a bare number, and both readers must
+normalize it.** `jsonencode` cannot tell a 1x1 numeric array from a scalar, so
+MATLAB writes `astralOnlyEmoji`'s single codepoint as `129417`, not `[129417]`;
+`jsondecode` does the mirror-image thing to Python's `[129417]`, handing MATLAB
+a 1x1 double. Neither writer can fix this — the ambiguity is in the language,
+not the encoder — so `inputCodepoints` and `elementLegacyDirNameCodepoints` go
+through `ndi.symmetry.fun.cases.asRow` on the MATLAB side and `cases.as_row` on
+the Python side before they are compared. This is the same collapse the
+rendered-value grammar of section 3 exists to avoid; these two fields are
+compared as numbers rather than through the grammar, so they need the
+normalizer instead. `singleSpace` and `astralOnlyEmoji` are the cases that hit
+it today.
+
 **The input is specified as codepoints, not as a literal.** Each side builds its
 input string from `inputCodepoints` — MATLAB via UTF-8 and `native2unicode`,
 Python via `chr()`. Neither side has to trust a source-file encoding, and
@@ -296,7 +309,7 @@ one.)
 | 7 | `fieldPresentInSomeStimuli` | `testFieldPresentInSomeStimuli` |
 | 8 | `blankStimuliExcludedByDefault` | `testBlankStimuliExcludedByDefault` |
 | 9 | `blankStimuliIncludedWhenOptionFalse` | `testBlankStimuliIncludedWhenOptionFalse` (same stimuli as 8, `excludeBlank=false`) |
-| 10 | `cellValuedConstantParameter` | `testCellValuedConstantParameter` — **known divergence** |
+| 10 | `cellValuedConstantParameter` | `testCellValuedConstantParameter` — a *predicted* divergence that the first real run refuted; now a hard assertion |
 | 11 | `vectorValuedVaryingParameter` | `testVectorValuedVaryingParameter` |
 | 12 | `allBlankStimuli` | `testAllBlankStimuliGivesEmpty` |
 | 13 | `nonNumericValues` | `testNonNumericValuesReturnedAsCell` |
@@ -329,12 +342,20 @@ the Python port are believed to disagree **today**. Both trace to one line:
 the same file already uses `isequaln` and the Python port uses `isequaln`
 semantics throughout.
 
-| case | predicted MATLAB | predicted Python |
-|---|---|---|
-| `cellValuedConstantParameter` | **errors** — `==` is undefined for two cell arrays | succeeds; `color` is constant |
-| `allNaNParameter` | `angle` reported **varying** — `eqlen(NaN,NaN)` is false | `angle` reported **constant** |
+| case | predicted MATLAB | predicted Python | **measured** |
+|---|---|---|---|
+| `cellValuedConstantParameter` | **errors** — `==` is undefined for two cell arrays | succeeds; `color` is constant | **prediction wrong.** MATLAB succeeds and agrees with Python: `angle` varying, `color` constant. Entry removed; the case is a hard assertion again |
+| `allNaNParameter` | `angle` reported **varying** — `eqlen(NaN,NaN)` is false | `angle` reported **constant** | **prediction right.** Still the only entry in `knownDivergences` |
 
-**These are source-read predictions, not measurements.** No MATLAB runtime was
+The two predictions shared a *cause* (`vlt.data.eqlen`) but were independent
+*claims*, and the first run on a real MATLAB split them. `eqlen` is still why
+`allNaNParameter` diverges; it is simply not true that
+`eqlen({'r','g','b'},{'r','g','b'})` throws, so the cell-valued case never
+diverged at all. **The mechanism is not established from source** —
+`vlt.data.eqemp` does reach a bare `x==y` on two cell arrays — only the
+outcome is, and the case now pins that outcome.
+
+**These were source-read predictions, not measurements.** No MATLAB runtime was
 available when this battery was written. The first real run settles them:
 
 * `readArtifacts/fun/whatVaries.testMatlabPythonSymmetry` reports rather than
@@ -358,8 +379,9 @@ A case *missing* from either artifact still only reports. That is list drift
 rather than a landed fix, and the key-set check in `testMatlabPythonSymmetry`
 already fails on it; failing twice for one cause is noise.
 
-If the divergences turn out to be real, the upstream fix is to swap `eqlen` for
-`isequaln` in `local_varyingFields`.
+`allNaNParameter` is real and still listed. The upstream fix is to swap
+`eqlen` for `isequaln` in `local_varyingFields`; until that lands the entry
+stays, and the auditor fails the build the moment it stops diverging.
 
 ## 6. Why the whatVaries generator records errors instead of failing
 

--- a/tests/+ndi/+symmetry/FUN_CASES_SCHEMA.md
+++ b/tests/+ndi/+symmetry/FUN_CASES_SCHEMA.md
@@ -346,13 +346,17 @@ available when this battery was written. The first real run settles them:
   case becomes a hard assertion again. A stale allow-list is how a symmetry suite
   goes quietly green over the bug it exists to watch.
 
-**Open contract question for Steve:** that auditor currently *reports* and never
-fails, so a stale allow-list entry lands as a line in the CI log rather than a red
-build — which is exactly the failure mode the paragraph above warns about. Whether
-`testKnownDivergencesAreStillReal` (and its Python twin `audit_known_divergences`)
-should **fail** on a stale entry instead of printing is deliberately left
-unresolved here; it is raised in the PR bodies on both sides. Report-not-fail
-stands until that is settled, and both languages must change together.
+**Settled: the auditor FAILS on a stale entry.** It previously reported and never
+failed, so a stale allow-list entry landed as a line in the CI log rather than a
+red build — the same failure mode as a silently skipped test, and exactly what
+the paragraph above warns about. `testKnownDivergencesAreStillReal` and its
+Python twin `audit_known_divergences` now both fail when a listed case starts
+agreeing across languages, so the entry gets removed and the case goes back to
+being a hard assertion.
+
+A case *missing* from either artifact still only reports. That is list drift
+rather than a landed fix, and the key-set check in `testMatlabPythonSymmetry`
+already fails on it; failing twice for one cause is noise.
 
 If the divergences turn out to be real, the upstream fix is to swap `eqlen` for
 `isequaln` in `local_varyingFields`.


### PR DESCRIPTION
Settles the open contract question in `tests/+ndi/+symmetry/FUN_CASES_SCHEMA.md` §5, which was addressed to you by name:

> **Open contract question for Steve:** that auditor currently *reports* and never fails, so a stale allow-list entry lands as a line in the CI log rather than a red build — which is exactly the failure mode the paragraph above warns about. Whether `testKnownDivergencesAreStillReal` (and its Python twin `audit_known_divergences`) should **fail** on a stale entry instead of printing is deliberately left unresolved here… Report-not-fail stands until that is settled, and **both languages must change together**.

Decided: **fail**. And then it immediately caught one.

## Why fail

A `knownDivergences` entry that has stopped diverging means the entry is stale. Under report-only that arrives as a line in a CI log — a suite going quietly green over the bug it exists to watch.

That is not hypothetical here. #73's remaining item was four symmetry checks that had been **skipping, not failing**, for exactly this reason: nothing red, nothing to read, so nobody looked. Report-only is the same shape of hole one layer up.

`testKnownDivergencesAreStillReal` now collects the stale entries and ends in `verifyEmpty`, naming them and what to do. A case **missing** from either artifact still only reports: that is list drift rather than a landed fix, the key-set check in `testMatlabPythonSymmetry` already fails on it, and failing twice for one cause is noise.

## What it caught, on its very first run

The first Stage 2 run of Waltham-Data-Science/NDI-python#75 was also the **first time this contract had ever been executed against a real MATLAB** — the schema said so and warned that first contact is a reconciliation. The auditor failed, correctly, on a stale entry. The schema predicted two divergences from source-reading alone; the run split them:

| case | predicted MATLAB | **measured MATLAB** |
|---|---|---|
| `allNaNParameter` | `angle` **varying** — `eqlen(NaN,NaN)` is false | **holds.** Stays listed, and remains the only entry |
| `cellValuedConstantParameter` | **errors** — `==` is undefined for two cell arrays | **refuted.** MATLAB succeeds: `angle` varying, `color` constant, matching the Python port's signature exactly |

The two predictions shared a *cause* (`vlt.data.eqlen`) but were independent *claims*. `eqlen` is still why `allNaNParameter` diverges; it is simply not true that `eqlen({'r','g','b'},{'r','g','b'})` throws.

So the entry is removed and `divergenceExpected` cleared. That flag is what makes `verifyWhatVariesExpected` **skip** a case:

```matlab
if d.divergenceExpected
    continue;
end
```

It was set because we predicted MATLAB would error, so asserting the recorded `expectedStatus = 'ok'` would have failed the generator on a known bug. With the prediction refuted, leaving it set would mean Stage 1 permanently not checking a case that passes — a silently skipped assertion, which is the exact failure mode this PR exists to close. The four value assertions pass: the recorded expectations were right all along; only the predicted **status** was wrong.

**The mechanism is deliberately not asserted.** `vlt.data.eqemp` does reach a bare `x==y` on two cell arrays, so *why* it returns true rather than throwing is not established from source. Only the outcome is, and the case now pins it. If that outcome is somehow specific to the MATLAB release CI runs, this case is where it will show up.

## Scope

Three files, all under `tests/+ndi/+symmetry`. `FUN_CASES_SCHEMA.md` gains, besides the decision above:

- §5 records **prediction alongside measurement**, so the next reader can see which claims survived contact rather than only the conclusion.
- §4 gains the rule the Python side was missing: `jsonencode` cannot tell a 1x1 numeric array from a scalar, so a one-element `int list` arrives as a bare number — `129417`, not `[129417]`. `jsondecode` does the mirror-image thing to Python's output. **Neither writer can fix it**, so both readers normalize: `asRow` here, `cases.as_row` there. MATLAB has always done this; Python had not, which is what the other two Stage 2 failures were.

## Sequencing — merge this one FIRST

An earlier revision of this description said "both or neither, landing this alone turns every symmetry run red." **That was wrong**, and described the shape of this branch's first commit only. The second commit removes `cellValuedConstantParameter` from `knownDivergences`, so once this is on `main` the list is just `{'allNaNParameter'}` and there is nothing stale for the failing auditor to catch.

Merging this first is in fact the better order. The symmetry job checks out the NDI-matlab branch whose *name matches the NDI-python branch*, falling back to `main`; the names differ, so Waltham-Data-Science/NDI-python#75 currently measures NDI-matlab **main**. Once this lands, #75's next run tests exactly this pairing — the validation neither PR can get on its own.

Nothing else goes red in the window: NDI-python `main` has no `fun` generators yet, so Stage 3's `fun` tests skip for lack of `pythonArtifacts`, and the auditor skips too, since it needs both artifacts.

## Validation

**Authored without a MATLAB runtime**, but this branch is not purely reasoned. The `knownDivergences` and `divergenceExpected` changes are driven by a measurement: the MATLAB artifact's signature for `cellValuedConstantParameter` is identical to Python's, which is what made the auditor fail.

The gate that matters here is this repo's own **Run symmetry tests** job, which executes Stage 1 `makeArtifacts` — where the newly-enabled `verifyWhatVariesExpected` assertions actually run.

---
_Generated by [Claude Code](https://claude.ai/code/session_01CqrNhfGnhKGcQvNiP2LNXK)_