### PR TITLE
Document the blech_clust spike_array axis order for both readers

### DIFF
--- a/src/ndi/+ndi/+fun/+export/blech_clust.m
+++ b/src/ndi/+ndi/+fun/+export/blech_clust.m
@@ -114,7 +114,8 @@ function blech_clust(stimulator, probe, epochID, outputfile, options)
 % blech_poisson_hmm.py). This function writes exactly what that code reads:
 %
 %   /spike_trains/dig_in_<N>/spike_array   uint8 (n_trials x n_units x
-%                                          duration_ms); 1 = spike in that
+%                                          duration_ms) AS BLECH_CLUST READS
+%                                          IT in Python; 1 = spike in that
 %                                          ms. Delivery is at column preStim.
 %                                          One group per tastant; N encodes
 %                                          identity. Group attributes record
@@ -125,6 +126,16 @@ function blech_clust(stimulator, probe, epochID, outputfile, options)
 %   /unit_descriptor                       compound table with Int32 columns
 %                                          single_unit, regular_spiking,
 %                                          fast_spiking (one row per unit).
+%
+% AXIS ORDER: MATLAB (column-major) and h5py/numpy (row-major) index HDF5
+% datasets in opposite orders, so a dataset written from MATLAB with
+% dimensions [d1 d2 d3] is reported by Python as shape (d3, d2, d1). The
+% shapes quoted above are the Python/blech_clust view, which is the contract
+% that matters; spike_array is written so that Python sees exactly
+% (n_trials, n_units, duration_ms). Reading the same dataset back with
+% MATLAB's h5read therefore yields the reverse, [duration_ms n_units
+% n_trials] -- that is correct, not a bug, and no transpose should be applied
+% on the Python side. (Issue #855.)
 %
 % USING THE OUTPUT FILE WITH BLECH_CLUST
 % --------------------------------------------------------------------------
@@ -162,9 +173,12 @@ function blech_clust(stimulator, probe, epochID, outputfile, options)
 %        posterior_proba    (n_trials x time_bins x n_states) state
 %                           probabilities over time
 %        log_likelihood, aic, bic, time
-%    In MATLAB, e.g.:
+%    Those shapes are again the Python view; the same reversal applies when
+%    reading the results in MATLAB, e.g.:
 %        pp = h5read('/tmp/mydata.h5', ...
 %             '/spike_trains/dig_in_0/generic_poisson_hmm_results/states_3/posterior_proba');
+%        % pp is [n_states x time_bins x n_trials]; permute(pp,[3 2 1]) gives
+%        % the (n_trials, time_bins, n_states) layout blech reports.
 %
 % The HMM is fit to one taste at a time (taste_num); repeat step 2-3 per
 % dig_in_<N> to analyze every tastant. The ensemble-state HMM methodology is

--- a/src/ndi/+ndi/+fun/+export/blech_clust_write.m
+++ b/src/ndi/+ndi/+fun/+export/blech_clust_write.m
@@ -40,6 +40,23 @@ function blech_clust_write(outputfile, unit_spiketimes, unit_info, onset_times, 
 % | verbose (1)         | 0/1 be verbose.                                     |
 % --------------------------------------------------------------------------
 %
+% AXIS ORDER OF /spike_trains/dig_in_<N>/spike_array
+% --------------------------------------------------------------------------
+% blech_clust requires the raster to have numpy shape (n_trials, n_units,
+% trial_duration_ms). MATLAB (column-major) and h5py/numpy (row-major) index
+% HDF5 datasets in opposite orders, so a dataset written from MATLAB with
+% dimensions [d1 d2 d3] is reported by Python as shape (d3, d2, d1). This
+% function therefore writes the dataset with MATLAB dimensions
+% [trial_dur_ms n_units n_trials], which Python reads back as
+% (n_trials, n_units, trial_dur_ms). Consequences:
+%   * reading spike_array back with MATLAB's h5read yields
+%     [trial_dur_ms n_units n_trials] -- the reverse of the Python shape,
+%     and correct;
+%   * Python consumers must NOT apply a compensating
+%     np.transpose(spike_array, (2,1,0)); the file is already in blech's
+%     order. (Issue #855.)
+% --------------------------------------------------------------------------
+%
 % See also: ndi.fun.export.blech_clust
 
     arguments


### PR DESCRIPTION
## Summary

Comment-only follow-up to [#856](https://github.com/VH-Lab/NDI-matlab/pull/856), which fixed the `spike_array` ordering reported in [#855](https://github.com/VH-Lab/NDI-matlab/issues/855). The behavior is already correct; this records the contract where a reader will actually find it.

## Why

`blech_clust_write.m` permutes `spike_array` to `[trial_dur_ms n_units n_trials]` before writing, so that h5py/numpy — which indexes HDF5 in the reverse order from MATLAB — reads it back as `(n_trials, n_units, trial_dur_ms)`. That is right, but it leaves two ways to reintroduce the bug:

1. **From MATLAB.** `h5read` on a correct file returns `[time units trials]`, which looks exactly like the originally reported bug, inviting someone to "fix" the writer back.
2. **From Python.** The `np.transpose(spike_train, (2, 1, 0))` workaround from the issue predates the fix; applied to a post-fix file it transposes correct data back to `(time, units, trials)`.

## Changes

- `blech_clust_write.m`: new "AXIS ORDER" section in the header stating that the quoted shapes are the Python view, that MATLAB's `h5read` returns the reverse and that this is correct, and that Python consumers must not apply a compensating transpose.
- `blech_clust.m`: same note in the output-file description, and a correction to the `posterior_proba` example in the "using the output file" walkthrough — it quoted blech's Python shape `(n_trials × time_bins × n_states)` directly next to a MATLAB `h5read` call that returns its reverse.

## Testing

No behavior change — the diff is comments only (verified: every changed line begins with `%`). Nothing was executed; no MATLAB was available in this environment, per `AGENTS.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015i3Mxth7ktnHjvBPK2wSz9

---
_Generated by [Claude Code](https://claude.ai/code/session_015i3Mxth7ktnHjvBPK2wSz9)_