### PR TITLE
Track failed document downloads and exclude from sync index

### DIFF
--- a/src/ndi/+ndi/+cloud/+sync/+internal/downloadNdiDocuments.m
+++ b/src/ndi/+ndi/+cloud/+sync/+internal/downloadNdiDocuments.m
@@ -62,6 +62,19 @@ function downloadedNdiDocuments = downloadNdiDocuments(cloudDatasetId, cloudDocu
         fprintf('Successfully retrieved metadata for %d documents.\n', numel(newNdiDocuments));
     end
 
+    % Only the completely-empty case was checked above. A *partial* result --
+    % ask for 50, get 47 -- passed through without a word, which is exactly
+    % what the silent pagination in issue #817 produces. Say so, or the
+    % caller reports a download that did not happen. An empty-string request
+    % means "download everything", so there is no requested count to compare.
+    isDownloadAllRequest = isscalar(cloudDocumentIds) && cloudDocumentIds == "";
+    if ~isDownloadAllRequest && numel(newNdiDocuments) < numel(cloudDocumentIds)
+        warning('NDI:cloud:sync:PartialDownload', ...
+            ['Requested %d documents from the cloud but received %d. ' ...
+             'The remaining documents were not downloaded.'], ...
+            numel(cloudDocumentIds), numel(newNdiDocuments));
+    end
+
     % 2. Handle associated data files
     if syncOptions.SyncFiles
         if syncOptions.Verbose

--- a/src/ndi/+ndi/+cloud/+sync/downloadNew.m
+++ b/src/ndi/+ndi/+cloud/+sync/downloadNew.m
@@ -30,6 +30,9 @@ function [success, errorMessage, report] = downloadNew(ndiDataset, syncOptions)
 %       report (struct) - Structure containing details of the changes applied.
 %           Fields:
 %           - downloaded_document_ids (string array)
+%           - failed (string array) - NDI IDs that were requested from the
+%             remote but did not arrive. These are deliberately left out of
+%             the sync index so the next sync requests them again.
 %
 %   See also:
 %       ndi.cloud.syncDataset
@@ -43,7 +46,12 @@ function [success, errorMessage, report] = downloadNew(ndiDataset, syncOptions)
 
     success = true;
     errorMessage = '';
-    report = struct('downloaded_document_ids', string.empty);
+    report = struct('downloaded_document_ids', string.empty, ...
+        'failed', string.empty);
+
+    % Remote documents we asked for and did not get. Declared here so the
+    % index update in step 5 can see it whichever branch below ran.
+    notObtainedNdiIds = string.empty;
 
     try
         syncOptions = ndi.cloud.sync.SyncOptions(syncOptions);
@@ -119,8 +127,26 @@ function [success, errorMessage, report] = downloadNew(ndiDataset, syncOptions)
                      report.downloaded_document_ids = string(docIds);
                 end
 
+                % What we asked for and did not receive. This has to be
+                % recorded: step 3 above works out what to fetch by diffing
+                % the remote list against the *index*, not against what is
+                % actually local, so any ID written into the index as synced
+                % is never requested again.
+                notObtainedNdiIds = setdiff(ndiIdsToDownload, ...
+                    report.downloaded_document_ids, 'stable');
+                report.failed = string(notObtainedNdiIds);
+
+                if ~isempty(notObtainedNdiIds)
+                    warning('NDI:cloud:sync:DocumentsNotDownloaded', ...
+                        ['%d of %d documents were not downloaded and remain ' ...
+                         'only on the remote. They stay outstanding and will ' ...
+                         'be retried on the next sync.'], ...
+                        numel(notObtainedNdiIds), numel(ndiIdsToDownload));
+                end
+
                 if syncOptions.Verbose
-                    fprintf('Completed downloading %d documents.\n', numel(ndiIdsToDownload));
+                    fprintf('Completed downloading %d of %d documents.\n', ...
+                        numel(report.downloaded_document_ids), numel(ndiIdsToDownload));
                 end
             end
         else
@@ -135,10 +161,22 @@ function [success, errorMessage, report] = downloadNew(ndiDataset, syncOptions)
             % Update local state after download
             [~, finalLocalDocumentIds] = ndi.cloud.sync.internal.listLocalDocuments(ndiDataset);
 
+            % Record only the remote documents that actually arrived.
+            % Writing the full remote list here was what made a missed
+            % document permanent: it lands in remoteDocumentIdsLastSync as
+            % though it had synced, and the setdiff in step 3 then excludes
+            % it from every future run. (The local side needs no such care --
+            % it is re-listed from the dataset above, so it cannot lie.)
+            % A filter rather than setdiff: this keeps the list's exact
+            % order and shape and removes only the missing entries, where
+            % setdiff would also silently deduplicate it.
+            syncedRemoteNdiIds = remoteDocumentIdMap.ndiId( ...
+                ~ismember(remoteDocumentIdMap.ndiId, notObtainedNdiIds));
+
             ndi.cloud.sync.internal.index.updateSyncIndex(...
                 ndiDataset, cloudDatasetId, ...
                 "LocalDocumentIds", finalLocalDocumentIds, ...
-                "RemoteDocumentIds", remoteDocumentIdMap.ndiId)
+                "RemoteDocumentIds", syncedRemoteNdiIds)
 
             if syncOptions.Verbose
                 fprintf('Sync index updated.\n');

--- a/src/ndi/+ndi/+cloud/+sync/mirrorFromRemote.m
+++ b/src/ndi/+ndi/+cloud/+sync/mirrorFromRemote.m
@@ -30,6 +30,9 @@ function [success, errorMessage, report] = mirrorFromRemote(ndiDataset, syncOpti
 %           Fields:
 %           - downloaded_document_ids (string array)
 %           - deleted_local_document_ids (string array)
+%           - failed (string array) - NDI IDs that were requested from the
+%             remote but did not arrive. These are deliberately left out of
+%             the sync index so they stay outstanding.
 %
 %   See also:
 %       ndi.cloud.syncDataset
@@ -43,7 +46,13 @@ function [success, errorMessage, report] = mirrorFromRemote(ndiDataset, syncOpti
 
     success = true;
     errorMessage = '';
-    report = struct('downloaded_document_ids', string.empty, 'deleted_local_document_ids', string.empty);
+    report = struct('downloaded_document_ids', string.empty, ...
+        'deleted_local_document_ids', string.empty, ...
+        'failed', string.empty);
+
+    % Remote documents we asked for and did not get. Declared here so the
+    % index update in Phase 4 can see it whichever branch below ran.
+    notObtainedNdiIds = string.empty;
 
     try
         syncOptions = ndi.cloud.sync.SyncOptions(syncOptions);
@@ -103,8 +112,21 @@ function [success, errorMessage, report] = mirrorFromRemote(ndiDataset, syncOpti
                      report.downloaded_document_ids = string(docIds);
                 end
 
+                % What we asked for and did not receive.
+                notObtainedNdiIds = setdiff(ndiIdsToDownload, ...
+                    report.downloaded_document_ids, 'stable');
+                report.failed = string(notObtainedNdiIds);
+
+                if ~isempty(notObtainedNdiIds)
+                    warning('NDI:cloud:sync:DocumentsNotDownloaded', ...
+                        ['%d of %d documents were not downloaded. The local ' ...
+                         'dataset is not yet a mirror of the remote.'], ...
+                        numel(notObtainedNdiIds), numel(ndiIdsToDownload));
+                end
+
                 if syncOptions.Verbose
-                    fprintf('Completed download phase.\n');
+                    fprintf('Completed download phase: %d of %d documents.\n', ...
+                        numel(report.downloaded_document_ids), numel(ndiIdsToDownload));
                 end
             end
         elseif syncOptions.Verbose
@@ -145,10 +167,22 @@ function [success, errorMessage, report] = mirrorFromRemote(ndiDataset, syncOpti
             % Update local state after update. Remote was not change by this mode
             [~, finalLocalDocumentIds] = ndi.cloud.sync.internal.listLocalDocuments(ndiDataset);
 
+            % Record only the remote documents that actually arrived. This
+            % mode recomputes what to download from the *local* list, so its
+            % retry path survives either way -- but writing the full remote
+            % list here still makes remoteDocumentIdsLastSync a statement
+            % about documents that were never fetched, which twoWaySync
+            % later reads as settled remote state.
+            % A filter rather than setdiff: this keeps the list's exact
+            % order and shape and removes only the missing entries, where
+            % setdiff would also silently deduplicate it.
+            syncedRemoteNdiIds = initialRemoteDocumentIdMap.ndiId( ...
+                ~ismember(initialRemoteDocumentIdMap.ndiId, notObtainedNdiIds));
+
             ndi.cloud.sync.internal.index.updateSyncIndex(...
                 ndiDataset, cloudDatasetId, ...
                 "LocalDocumentIds", finalLocalDocumentIds, ...
-                "RemoteDocumentIds", initialRemoteDocumentIdMap.ndiId)
+                "RemoteDocumentIds", syncedRemoteNdiIds)
 
             if syncOptions.Verbose
                 fprintf('Sync index updated.\n');


### PR DESCRIPTION
## Summary
This PR adds tracking of documents that fail to download during cloud synchronization operations and ensures they are not marked as synced in the index. This prevents permanently losing track of documents that should be retried on the next sync.

## Key Changes

- **Added `failed` field to sync reports**: Both `downloadNew` and `mirrorFromRemote` now return a `failed` array containing NDI IDs that were requested but not received from the remote.

- **Filter sync index updates**: Instead of writing all remote documents to the sync index, only documents that were actually downloaded are recorded. This ensures failed downloads remain outstanding and will be retried on the next sync.

- **Added warning messages**: When documents fail to download, users are now warned with details about how many documents were not retrieved and that they will be retried.

- **Improved verbose logging**: Updated progress messages to show the ratio of downloaded documents (e.g., "Completed downloading 47 of 50 documents").

- **Added partial download detection**: `downloadNdiDocuments` now warns when a partial result is received (e.g., requesting 50 documents but only getting 47), which can occur due to silent pagination issues.

## Implementation Details

- The `notObtainedNdiIds` variable is declared early in both sync functions so it's accessible to the index update logic regardless of which code path executes.

- Failed documents are computed using `setdiff` between requested and downloaded IDs, maintaining stable ordering.

- The sync index update uses a filter operation (`~ismember`) rather than `setdiff` to preserve the exact order and shape of the remote document list while removing only missing entries.

- Comments explain why this approach is necessary: the sync index is used to determine what to fetch in future runs via `setdiff` against the remote list, so any document marked as synced will never be requested again.

https://claude.ai/code/session_01CYUMTzEfXiqM5PrtPBZYYi