### PR TITLE
+cloud/profile: move preferences to ~/.ndi/ and let findIndex accept nickname/email/UID

### DIFF
--- a/src/ndi/+ndi/+cloud/profile.m
+++ b/src/ndi/+ndi/+cloud/profile.m
@@ -45,12 +45,17 @@ classdef profile < matlab.mixin.CustomDisplay & handle
 %
 %   Profile metadata is persisted to:
 %
-%       fullfile(prefdir, 'NDI_Cloud_Profiles.json')
+%       fullfile(userHome, '.ndi', 'NDI_Cloud_Profiles.json')
 %
 %   The vault never sees that file; the AES backend writes ciphertext
 %   to a sibling file:
 %
-%       fullfile(prefdir, 'NDI_Cloud_Secrets.json')
+%       fullfile(userHome, '.ndi', 'NDI_Cloud_Secrets.json')
+%
+%   The location was moved from MATLAB's prefdir to ~/.ndi/ so that
+%   ndi-python (which has always defaulted to ~/.ndi/) and MATLAB share
+%   the same saved profiles by default. A legacy pair in prefdir is
+%   migrated on first load. See ndi-matlab#920 and ndi-python#168.
 %
 %   Typical usage:
 %
@@ -67,10 +72,23 @@ classdef profile < matlab.mixin.CustomDisplay & handle
 
     properties (Constant)
         % Filename - JSON file holding profile list and DefaultUID.
-        Filename = fullfile(prefdir, 'NDI_Cloud_Profiles.json')
+        % Kept in sync with ndi.cloud.profile.userPrefDir(); inlined here
+        % because Constant property initializers cannot reliably call
+        % static methods on their own class across every supported MATLAB
+        % release.
+        Filename = fullfile(char(java.lang.System.getProperty('user.home')), ...
+                            '.ndi', 'NDI_Cloud_Profiles.json')
 
         % SecretsFilename - AES backend's ciphertext file.
-        SecretsFilename = fullfile(prefdir, 'NDI_Cloud_Secrets.json')
+        SecretsFilename = fullfile(char(java.lang.System.getProperty('user.home')), ...
+                                   '.ndi', 'NDI_Cloud_Secrets.json')
+
+        % LegacyFilename - historical location under MATLAB's prefdir.
+        % Kept for one-time migration only; never written to.
+        LegacyFilename        = fullfile(prefdir, 'NDI_Cloud_Profiles.json')
+
+        % LegacySecretsFilename - historical AES ciphertext file.
+        LegacySecretsFilename = fullfile(prefdir, 'NDI_Cloud_Secrets.json')
     end
 
     properties (Constant, Access = private)
@@ -124,6 +142,7 @@ classdef profile < matlab.mixin.CustomDisplay & handle
         function loadFromDisk(obj)
         %LOADFROMDISK Read profiles and DefaultUID from JSON. CurrentUID
         %is intentionally not persisted (per-session state).
+            ndi.cloud.profile.migrateLegacyIfNeeded();
             if ~isfile(obj.Filename); return; end
             try
                 txt = fileread(obj.Filename);
@@ -144,6 +163,7 @@ classdef profile < matlab.mixin.CustomDisplay & handle
 
         function saveToDisk(obj)
         %SAVETODISK Write profiles and DefaultUID. CurrentUID is omitted.
+            ndi.cloud.profile.ensurePrefDir();
             S = struct('Profiles', obj.Profiles, ...
                        'DefaultUID', obj.DefaultUID);
             try
@@ -165,14 +185,46 @@ classdef profile < matlab.mixin.CustomDisplay & handle
             end
         end
 
-        function idx = findIndex(obj, uid)
-        %FINDINDEX Return the index of the profile with the given UID.
-            mask = strcmp({obj.Profiles.UID}, uid);
-            idx = find(mask, 1, 'first');
-            if isempty(idx)
+        function idx = findIndex(obj, key)
+        %FINDINDEX Resolve KEY to a profile index.
+        %
+        %   KEY may be a UID (exact match), a Nickname (exact match), or an
+        %   Email (case-insensitive exact match), tried in that order. UID
+        %   wins outright; among nickname/email matches an ambiguous
+        %   result throws NDI:cloud:profile:ambiguousProfile rather than
+        %   silently picking one. No match throws
+        %   NDI:cloud:profile:unknownProfile.
+            if isempty(obj.Profiles)
                 error('NDI:cloud:profile:unknownProfile', ...
-                    'Unknown profile UID "%s".', uid);
+                    'Unknown profile "%s" (no profiles saved).', key);
             end
+            uidHit = find(strcmp({obj.Profiles.UID}, key), 1, 'first');
+            if ~isempty(uidHit)
+                idx = uidHit;
+                return;
+            end
+            nickHits = find(strcmp({obj.Profiles.Nickname}, key));
+            if isscalar(nickHits)
+                idx = nickHits;
+                return;
+            elseif numel(nickHits) > 1
+                cands = strjoin({obj.Profiles(nickHits).UID}, ', ');
+                error('NDI:cloud:profile:ambiguousProfile', ...
+                    'Nickname "%s" matches multiple profiles (%s); use the UID to disambiguate.', ...
+                    key, cands);
+            end
+            emailHits = find(strcmpi({obj.Profiles.Email}, key));
+            if isscalar(emailHits)
+                idx = emailHits;
+                return;
+            elseif numel(emailHits) > 1
+                cands = strjoin({obj.Profiles(emailHits).UID}, ', ');
+                error('NDI:cloud:profile:ambiguousProfile', ...
+                    'Email "%s" matches multiple profiles (%s); use the UID to disambiguate.', ...
+                    key, cands);
+            end
+            error('NDI:cloud:profile:unknownProfile', ...
+                'Unknown profile "%s" (not a UID, Nickname, or Email).', key);
         end
 
         function setSecretInternal(obj, key, value)
@@ -291,6 +343,7 @@ classdef profile < matlab.mixin.CustomDisplay & handle
         end
 
         function aesWriteSecret(filename, key, value)
+            ndi.cloud.profile.ensurePrefDir();
             keyBytes = ndi.cloud.profile.aesKeyBytes();
             keySpec  = javax.crypto.spec.SecretKeySpec(keyBytes, 'AES');
             cipher   = javax.crypto.Cipher.getInstance('AES/CBC/PKCS5Padding');
@@ -445,6 +498,69 @@ classdef profile < matlab.mixin.CustomDisplay & handle
 
     methods (Static)
 
+        function d = userPrefDir()
+        %NDI.CLOUD.PROFILE.USERPREFDIR Cross-language NDI preferences directory.
+        %
+        %   Returns fullfile(userHome, '.ndi'). Uses Java to resolve the
+        %   user's home directory so the same location resolves on every
+        %   platform. ndi-python already writes to ~/.ndi/ by default,
+        %   so MATLAB sharing this location lets the two clients see
+        %   each other's saved profiles without per-user configuration.
+            home = char(java.lang.System.getProperty('user.home'));
+            d = fullfile(home, '.ndi');
+        end
+
+        function ensurePrefDir()
+        %NDI.CLOUD.PROFILE.ENSUREPREFDIR Create the ~/.ndi directory on demand.
+            d = ndi.cloud.profile.userPrefDir();
+            if ~isfolder(d)
+                try
+                    mkdir(d);
+                catch ME
+                    warning('NDI:cloud:profile:mkdirFailed', ...
+                        'Could not create %s: %s', d, ME.message);
+                end
+            end
+        end
+
+        function migrateLegacyIfNeeded()
+        %NDI.CLOUD.PROFILE.MIGRATELEGACYIFNEEDED Copy any old prefdir profiles into ~/.ndi/.
+        %
+        %   One-time, best-effort. If the new location already has a
+        %   profiles file, this is a no-op -- the new location wins.
+        %   The legacy files are left in place (this is a copy, not a
+        %   move) so a downgrade to a pre-migration MATLAB keeps
+        %   working, at the cost of a stale set that will drift.
+            newProfiles = ndi.cloud.profile.Filename;
+            oldProfiles = ndi.cloud.profile.LegacyFilename;
+            if isfile(newProfiles)
+                return;
+            end
+            if ~isfile(oldProfiles)
+                return;
+            end
+            ndi.cloud.profile.ensurePrefDir();
+            try
+                copyfile(oldProfiles, newProfiles);
+            catch ME
+                warning('NDI:cloud:profile:migrateFailed', ...
+                    'Could not migrate %s to %s: %s', ...
+                    oldProfiles, newProfiles, ME.message);
+                return;
+            end
+            oldSecrets = ndi.cloud.profile.LegacySecretsFilename;
+            newSecrets = ndi.cloud.profile.SecretsFilename;
+            if isfile(oldSecrets) && ~isfile(newSecrets)
+                try
+                    copyfile(oldSecrets, newSecrets);
+                catch ME
+                    warning('NDI:cloud:profile:migrateFailed', ...
+                        'Could not migrate %s to %s: %s', ...
+                        oldSecrets, newSecrets, ME.message);
+                end
+            end
+        end
+
         function obj = getSingleton()
         %NDI.CLOUD.PROFILE.GETSINGLETON Return the shared profile manager.
             persistent objStore
@@ -490,22 +606,23 @@ classdef profile < matlab.mixin.CustomDisplay & handle
             obj.saveToDisk();
         end
 
-        function remove(uid)
+        function remove(key)
         %NDI.CLOUD.PROFILE.REMOVE Delete a profile and its stored secret.
         %If the removed profile was the current and/or default, both
-        %selections are cleared.
+        %selections are cleared. KEY is UID | Nickname | Email (see findIndex).
             arguments
-                uid (1,:) char
+                key (1,:) char
             end
             obj = ndi.cloud.profile.getSingleton();
-            idx = obj.findIndex(uid);
-            secretKey = obj.Profiles(idx).PasswordSecret;
+            idx = obj.findIndex(key);
+            resolvedUid = obj.Profiles(idx).UID;
+            secretKey   = obj.Profiles(idx).PasswordSecret;
             obj.removeSecretInternal(secretKey);
             obj.Profiles(idx) = [];
-            if strcmp(obj.CurrentUID, uid)
+            if strcmp(obj.CurrentUID, resolvedUid)
                 obj.CurrentUID = '';
             end
-            if strcmp(obj.DefaultUID, uid)
+            if strcmp(obj.DefaultUID, resolvedUid)
                 obj.DefaultUID = '';
             end
             obj.saveToDisk();
@@ -517,18 +634,18 @@ classdef profile < matlab.mixin.CustomDisplay & handle
             p = ndi.cloud.profile.profileForUID(obj, obj.CurrentUID);
         end
 
-        function setCurrent(uid)
+        function setCurrent(key)
         %NDI.CLOUD.PROFILE.SETCURRENT Set the current profile (session only).
         %
+        %   KEY is UID | Nickname | Email; the resolved UID is stored.
         %   The change does NOT touch disk. CurrentUID is per-session
         %   so two MATLAB instances can hold different active
         %   profiles concurrently.
             arguments
-                uid (1,:) char
+                key (1,:) char
             end
             obj = ndi.cloud.profile.getSingleton();
-            obj.findIndex(uid);   % validates existence
-            obj.CurrentUID = uid;
+            obj.CurrentUID = obj.Profiles(obj.findIndex(key)).UID;
         end
 
         function p = getDefault()
@@ -537,19 +654,19 @@ classdef profile < matlab.mixin.CustomDisplay & handle
             p = ndi.cloud.profile.profileForUID(obj, obj.DefaultUID);
         end
 
-        function setDefault(uid)
-        %NDI.CLOUD.PROFILE.SETDEFAULT Persist UID as the default profile.
+        function setDefault(key)
+        %NDI.CLOUD.PROFILE.SETDEFAULT Persist the profile as the default.
         %
+        %   KEY is UID | Nickname | Email; the resolved UID is persisted.
         %   The constructor copies DefaultUID into CurrentUID at the
         %   start of every MATLAB session. Setting a default does not
         %   change CurrentUID for the current session; use setCurrent
         %   for that, or switchProfile to also reconfigure env vars.
             arguments
-                uid (1,:) char
+                key (1,:) char
             end
             obj = ndi.cloud.profile.getSingleton();
-            obj.findIndex(uid);   % validates existence
-            obj.DefaultUID = uid;
+            obj.DefaultUID = obj.Profiles(obj.findIndex(key)).UID;
             obj.saveToDisk();
         end
 
@@ -603,20 +720,21 @@ classdef profile < matlab.mixin.CustomDisplay & handle
             obj.saveToDisk();
         end
 
-        function switchProfile(uid)
-        %NDI.CLOUD.PROFILE.SWITCHPROFILE Make UID active for this session.
+        function switchProfile(key)
+        %NDI.CLOUD.PROFILE.SWITCHPROFILE Make a saved profile active for this session.
         %
+        %   KEY is UID | Nickname | Email (see findIndex).
         %   Calls ndi.cloud.logout, sets the env vars
         %   CLOUD_API_ENVIRONMENT (= profile.Stage),
         %   NDI_CLOUD_USERNAME    (= profile.Email), and
         %   NDI_CLOUD_PASSWORD    (= getPassword(uid)),
-        %   then marks UID as the current profile (in memory only —
-        %   does not change DefaultUID).
+        %   then marks the resolved profile as the current profile
+        %   (in memory only — does not change DefaultUID).
             arguments
-                uid (1,:) char
+                key (1,:) char
             end
             obj  = ndi.cloud.profile.getSingleton();
-            idx  = obj.findIndex(uid);
+            idx  = obj.findIndex(key);
             prof = obj.Profiles(idx);
             try
                 ndi.cloud.logout();
@@ -628,7 +746,7 @@ classdef profile < matlab.mixin.CustomDisplay & handle
             setenv('CLOUD_API_ENVIRONMENT', prof.Stage);
             setenv('NDI_CLOUD_USERNAME',    prof.Email);
             setenv('NDI_CLOUD_PASSWORD',    obj.getSecretInternal(prof.PasswordSecret));
-            obj.CurrentUID = uid;
+            obj.CurrentUID = prof.UID;
         end
 
         function path = filename()

--- a/tests/+ndi/+unittest/+cloud/profileTests.m
+++ b/tests/+ndi/+unittest/+cloud/profileTests.m
@@ -271,12 +271,75 @@ classdef profileTests < matlab.unittest.TestCase
             testCase.verifyEqual(getenv('CLOUD_API_ENVIRONMENT'), 'dev');
         end
 
-        function testFilenameLivesInPrefdir(testCase)
+        function testFilenameLivesInUserPrefDir(testCase)
+            % Filenames moved from MATLAB's prefdir to ~/.ndi/ so that
+            % ndi-python and MATLAB share saved profiles by default
+            % (see ndi-matlab#920 / ndi-python#168).
             f = ndi.cloud.profile.filename();
             testCase.verifyClass(f, 'char');
-            testCase.verifyTrue(startsWith(f, prefdir), ...
-                sprintf('Expected filename to start with prefdir (%s) but got %s', ...
-                    prefdir, f));
+            expected = ndi.cloud.profile.userPrefDir();
+            testCase.verifyTrue(startsWith(f, expected), ...
+                sprintf('Expected filename to start with %s but got %s', ...
+                    expected, f));
+        end
+
+        function testFindIndexByNickname(testCase)
+            uidLab = ndi.cloud.profile.add('lab-primary', 'me@lab.org', 'pw1');
+            ndi.cloud.profile.add('dev-account', 'dev@lab.org', 'pw2');
+            testCase.verifyEqual( ...
+                ndi.cloud.profile.get('lab-primary').UID, uidLab);
+        end
+
+        function testFindIndexByEmailIsCaseInsensitive(testCase)
+            uidLab = ndi.cloud.profile.add('lab-primary', 'me@lab.org', 'pw1');
+            ndi.cloud.profile.add('dev-account', 'dev@lab.org', 'pw2');
+            testCase.verifyEqual( ...
+                ndi.cloud.profile.get('ME@LAB.ORG').UID, uidLab);
+        end
+
+        function testFindIndexAmbiguousNicknameThrows(testCase)
+            uidA = ndi.cloud.profile.add('shared', 'a@lab.org', 'pwA');
+            uidB = ndi.cloud.profile.add('shared', 'b@lab.org', 'pwB');
+            try
+                ndi.cloud.profile.get('shared');
+                testCase.verifyFail('Ambiguous nickname should have thrown.');
+            catch ME
+                testCase.verifyEqual(ME.identifier, ...
+                    'NDI:cloud:profile:ambiguousProfile');
+                testCase.verifyTrue(contains(ME.message, uidA));
+                testCase.verifyTrue(contains(ME.message, uidB));
+            end
+        end
+
+        function testSwitchProfileByNicknameStoresResolvedUid(testCase)
+            uidLab = ndi.cloud.profile.add('lab-primary', 'me@lab.org', 'pw1');
+            saved = ndi.unittest.cloud.profileTests.snapshotEnv();
+            cleanup = onCleanup(@() ...
+                ndi.unittest.cloud.profileTests.restoreEnv(saved)); %#ok<NASGU>
+            ndi.cloud.profile.switchProfile('lab-primary');
+            testCase.verifyEqual(getenv('NDI_CLOUD_USERNAME'), 'me@lab.org');
+            testCase.verifyEqual(getenv('NDI_CLOUD_PASSWORD'), 'pw1');
+            cur = ndi.cloud.profile.getCurrent();
+            testCase.assertNotEmpty(cur);
+            testCase.verifyEqual(cur.UID, uidLab, ...
+                'switchProfile must store the resolved UID, not the raw key.');
+        end
+
+        function testSetCurrentByEmailStoresResolvedUid(testCase)
+            uidLab = ndi.cloud.profile.add('lab-primary', 'me@lab.org', 'pw1');
+            ndi.cloud.profile.setCurrent('me@lab.org');
+            cur = ndi.cloud.profile.getCurrent();
+            testCase.assertNotEmpty(cur);
+            testCase.verifyEqual(cur.UID, uidLab);
+        end
+
+        function testRemoveByNicknameClearsCurrentAndDefault(testCase)
+            uidLab = ndi.cloud.profile.add('lab-primary', 'me@lab.org', 'pw1');
+            ndi.cloud.profile.setCurrent(uidLab);
+            ndi.cloud.profile.setDefault(uidLab);
+            ndi.cloud.profile.remove('lab-primary');
+            testCase.verifyEmpty(ndi.cloud.profile.getCurrent());
+            testCase.verifyEmpty(ndi.cloud.profile.getDefault());
         end
 
         function testEditorSmoke(testCase)


### PR DESCRIPTION
Closes #920. Coordinated with waltham-data-science/ndi-python#168.

## Summary

`ndi.cloud.profile.switchProfile('lab-primary')` now works — no more UUID hex needed for saved-profile login. And the preferences directory moved from MATLAB's `prefdir` to `~/.ndi/` so MATLAB and ndi-python share saved profiles by default.

## What changed

**On-disk location moved to `~/.ndi/`.**
- `Filename` / `SecretsFilename` now resolve to `fullfile(userHome, '.ndi', ...)` via a new public `userPrefDir()` static (Java-based, cross-platform).
- New `ensurePrefDir()` creates `~/.ndi/` on demand from `saveToDisk` and `aesWriteSecret` — the first write will not fail before anyone has touched the directory.
- New `migrateLegacyIfNeeded()` runs on first `loadFromDisk`: if `~/.ndi/NDI_Cloud_Profiles.json` does not exist but the old `fullfile(prefdir, 'NDI_Cloud_Profiles.json')` pair does, both files are copied over (best-effort; legacy left in place so a downgrade to a pre-migration MATLAB still works). Upgraders keep their saved profiles.
- The AES key formula (`SHA-256([host " " user " " "NDI Cloud"])`, first 16 bytes, AES-128-CBC/PKCS7) was already interchangeable with ndi-python; only the directory was blocking sharing.

**`findIndex` widened.**
- Accepts a UID (exact), a Nickname (exact), or an Email (case-insensitive), in that order.
- Ambiguous nickname/email throws `NDI:cloud:profile:ambiguousProfile` naming the candidate UIDs rather than silently picking one.
- Unknown key still throws `NDI:cloud:profile:unknownProfile`.
- `remove`, `setCurrent`, `setDefault`, `switchProfile` now store the resolved UID (not the caller's raw key) so `adoptDefaultAsCurrent`, the remove-cleanup checks, and any other UID comparison stay correct when the caller passed a nickname.
- Every other UID-taking static (`get`, `getPassword`, `setPassword`, `getStage`, `setStage`) inherits the widened lookup automatically because they dispatch through `findIndex`.

## Tests

Updated `tests/+ndi/+unittest/+cloud/profileTests.m`:
- `testFilenameLivesInPrefdir` retargeted to `userPrefDir()` (`testFilenameLivesInUserPrefDir`).
- New tests: lookup by nickname; case-insensitive email; ambiguous-nickname error names candidates; `switchProfile` by nickname stores the resolved UID; `setCurrent` by email stores the resolved UID; `remove` by nickname clears current/default when they matched.

The MATLAB test suite has not been run in this session (no MATLAB installed). Reviewer should run `ndi.unittest.cloud.profileTests` locally before merging.

## Test plan

- [ ] `runtests('ndi.unittest.cloud.profileTests')` green
- [ ] Manual: `ndi.cloud.profile.filename()` returns `~/.ndi/NDI_Cloud_Profiles.json`
- [ ] Manual: with old prefdir profiles present, first `ndi.cloud.profile.list()` after upgrade shows them (migration ran)
- [ ] Manual: after this PR + ndi-python#168 land, a profile added in MATLAB is visible from Python's `ndi.cloud.profile.get_current()` (proves shared `~/.ndi/` files round-trip both ways)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017zDzZ9joBkZjzeMLfWZZk7


---
_Generated by [Claude Code](https://claude.ai/code/session_017zDzZ9joBkZjzeMLfWZZk7)_