### PR TITLE
OldDatasetTest: explain why the corpus is copied before opening (parity note for ndi-python#99)

### DIFF
--- a/tests/+ndi/+unittest/+dataset/OldDatasetTest.m
+++ b/tests/+ndi/+unittest/+dataset/OldDatasetTest.m
@@ -5,7 +5,14 @@ classdef OldDatasetTest < matlab.unittest.TestCase
             % Construct path to the dataset
             originalDatasetPath = fullfile(ndi.toolboxdir, 'ndi_common', 'example_datasets', 'oldDataset');
 
-            % Copy to a temporary directory so we don't modify the example
+            % Copy to a temporary directory so we don't modify the example.
+            % ndi.dataset.dir runs repairDatasetSessionInfo on a legacy
+            % dataset_session_info document during construction, which writes
+            % new session_in_a_dataset documents and deletes the old one.
+            % Opening originalDatasetPath directly would mutate the shared
+            % example. Python's tests/matlab_tests/test_dabrowska.py fixture
+            % follows the same copy-before-open pattern for its shared corpus.
+            % See ndi-python issue #99.
             tempDir = tempname;
             copyfile(originalDatasetPath, tempDir);
             testCase.addTeardown(@rmdir, tempDir, 's');


### PR DESCRIPTION
## Summary

Parity note for [Waltham-Data-Science/NDI-python#99](https://github.com/Waltham-Data-Science/NDI-python/issues/99).

The Python fixture `tests/matlab_tests/test_dabrowska.py` was opening a shared dabrowska corpus in place, so `ndi.dataset.ndi_dataset(...)` running `repairDatasetSessionInfo` during construction was mutating the shared tree (issue #99 in ndi-python). The sibling PR there switches that fixture to copy-before-open.

On the MATLAB side, `tests/+ndi/+unittest/+dataset/OldDatasetTest.m` already follows the correct pattern — it copies `example_datasets/oldDataset` to `tempname` before calling `ndi.dataset.dir(datasetPath)`. This PR just adds a comment explaining **why** the copy is essential (`repairDatasetSessionInfo` runs during construction and writes/deletes documents) and cross-references the Python issue, so the pattern stays visible if MATLAB later grows a test that opens an external shared corpus.

## Parity status

- `ndi.dataset.dir` constructor (`src/ndi/+ndi/+dataset/dir.m`) and `build_session_info` (`src/ndi/+ndi/dataset.m`) both call `repairDatasetSessionInfo` — same in Python's `_dataset.py`. The mutation-on-open behavior is in full parity between the two codebases.
- The larger design question — whether `repairDatasetSessionInfo` should run on construction at all — is deferred and would land in both repos together.

## Test plan

- [ ] `runtests` continues to pass; `OldDatasetTest` behavior is unchanged (comment-only edit).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BbK6Xis72nMM1EpBYEKsPK

---
_Generated by [Claude Code](https://claude.ai/code/session_01BbK6Xis72nMM1EpBYEKsPK)_