### PR TITLE
simple_calc_v2_schema: use Infinity, not Inf (invalid JSON)

### DIFF
--- a/src/ndi/ndi_common/schema_documents/apps/calculations/simple_calc_v2_schema.json
+++ b/src/ndi/ndi_common/schema_documents/apps/calculations/simple_calc_v2_schema.json
@@ -18,7 +18,7 @@
 			"name": "answer",
 			"type": "double",
 			"default_value": 1,
-			"parameters": [-Inf,Inf,0],
+			"parameters": [-Infinity,Infinity,0],
 			"queryable": 1,
 			"documentation": "The value for this example calculation."
 		}


### PR DESCRIPTION
Coordinated with waltham-data-science/ndi-python#(sibling PR), which fixes the same file synced into ndi-python by that repo's PR #177 and turned CI red there after #178 landed a bundled-schema tripwire test.

## Summary

`src/ndi/ndi_common/schema_documents/apps/calculations/simple_calc_v2_schema.json` line 21 was:

```json
"parameters": [-Inf,Inf,0],
```

`Inf` / `-Inf` are MATLAB literals, not valid JSON tokens. MATLAB's own `jsonencode` emits `Infinity` (not `Inf`) when `ConvertInfAndNaN=false`, and `jsondecode` only accepts `Infinity`, so this fix works for both languages. The sibling v1 schema uses `Infinity` — v2 was likely hand-edited to `Inf` thinking it was equivalent.

## Diff

One line:

```diff
-			"parameters": [-Inf,Inf,0],
+			"parameters": [-Infinity,Infinity,0],
```

## Test plan

- [ ] Verify with `jsondecode(fileread('.../simple_calc_v2_schema.json'))` that the file still round-trips in MATLAB.
- [ ] After merge, the sync into ndi-python stays clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017zDzZ9joBkZjzeMLfWZZk7


---
_Generated by [Claude Code](https://claude.ai/code/session_017zDzZ9joBkZjzeMLfWZZk7)_