### PR TITLE
Fix invalid bare Inf in two ndi_common schema JSON files

### DIFF
--- a/src/ndi/ndi_common/schema_documents/apps/calculations/simple_calc_schema.json
+++ b/src/ndi/ndi_common/schema_documents/apps/calculations/simple_calc_schema.json
@@ -18,7 +18,7 @@
 			"name": "answer",
 			"type": "double",
 			"default_value": 1,
-			"parameters": [-Inf,Inf,0],
+			"parameters": [-Infinity,Infinity,0],
 			"queryable": 1,
 			"documentation": "The value for this example calculation."
 		}

--- a/src/ndi/ndi_common/schema_documents/apps/markgarbage/valid_interval_schema.json
+++ b/src/ndi/ndi_common/schema_documents/apps/markgarbage/valid_interval_schema.json
@@ -17,7 +17,7 @@
 			"name": "t0",
 			"type": "double",
 			"default_value": 0,
-			"parameters": [-Inf,Inf,0],
+			"parameters": [-Infinity,Infinity,0],
 			"queryable": 1,
 			"documentation": "t0, in time units of timeref_structt0"
 		},
@@ -33,7 +33,7 @@
 			"name": "t1",
 			"type": "double",
 			"default_value": 1,
-			"parameters": [-Inf,Inf,0],
+			"parameters": [-Infinity,Infinity,0],
 			"queryable": 1,
 			"documentation": "t1, in time units of timeref_structt0"
 		}


### PR DESCRIPTION
## Summary

- `ndi_common/schema_documents/apps/calculations/simple_calc_schema.json` and `.../markgarbage/valid_interval_schema.json` still emitted bare `Inf`/`-Inf` tokens for their parameter bounds. That is not valid JSON; `json.loads` rejects it, so downstream Python readers cannot parse these files.
- Replace with `Infinity`/`-Infinity`, matching the fix already applied in `simple_calc_v2_schema.json` (#926). The two sibling files were missed at the time.

Reported in [Waltham-Data-Science/NDI-python#199](https://github.com/Waltham-Data-Science/NDI-python/issues/199).

## Test plan
- [x] `simple_calc_schema.json` and `valid_interval_schema.json` are now byte-for-byte identical to the NDI-python copies in `src/ndi/ndi_common/`.
- [x] `pytest tests/test_ndi_common_matlab_sync.py` in the paired NDI-python branch passes with `NDI_MATLAB_PATH` pointed at this branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UZBqnnKB71n2Yrex4YAYWv

---
_Generated by [Claude Code](https://claude.ai/code/session_01UZBqnnKB71n2Yrex4YAYWv)_