### PR TITLE
Push CI badges to a dedicated `badges` branch

### DIFF
--- a/.github/actions/push-badges-to-branch/action.yml
+++ b/.github/actions/push-badges-to-branch/action.yml
@@ -33,8 +33,15 @@ runs:
       run: |
         set -euo pipefail
 
+        # Resolve $BADGES_DIR to an absolute path *now*, so that the SVG
+        # paths in $svgs stay valid after we `cd` into a working directory.
+        SRC_DIR="$(cd "$BADGES_DIR" 2>/dev/null && pwd || true)"
+
         shopt -s nullglob
-        svgs=("$BADGES_DIR"/*.svg)
+        svgs=()
+        if [ -n "$SRC_DIR" ]; then
+          svgs=("$SRC_DIR"/*.svg)
+        fi
         if (( ${#svgs[@]} == 0 )); then
           echo "No badge SVGs in $BADGES_DIR - nothing to push."
           exit 0
@@ -45,7 +52,6 @@ runs:
 
         REMOTE="https://x-access-token:${GH_TOKEN}@github.com/${GITHUB_REPOSITORY}.git"
         WORKDIR="$(mktemp -d)"
-        SRC_DIR="$PWD/$BADGES_DIR"
 
         cd "$WORKDIR"
         git init -q -b "$BADGES_BRANCH" .

--- a/.github/actions/push-badges-to-branch/action.yml
+++ b/.github/actions/push-badges-to-branch/action.yml
@@ -1,0 +1,99 @@
+name: 'Push badges to badges branch'
+description: >-
+  Copy generated SVG badges from the workspace into the repository's dedicated
+  `badges` branch under `<sanitised-source-ref>/`, so that working branches
+  never receive badge commits.
+
+inputs:
+  source-ref:
+    description: 'Name of the source branch these badges came from (e.g. main, or a PR head ref).'
+    required: true
+  badges-branch:
+    description: 'Name of the dedicated badges branch.'
+    required: false
+    default: 'badges'
+  badges-dir:
+    description: 'Directory in the workspace holding generated badge SVGs.'
+    required: false
+    default: '.github/badges'
+  token:
+    description: 'GITHUB_TOKEN or PAT with write access to the repo.'
+    required: true
+
+runs:
+  using: 'composite'
+  steps:
+    - name: Publish badges
+      shell: bash
+      env:
+        SOURCE_REF: ${{ inputs.source-ref }}
+        BADGES_BRANCH: ${{ inputs.badges-branch }}
+        BADGES_DIR: ${{ inputs.badges-dir }}
+        GH_TOKEN: ${{ inputs.token }}
+      run: |
+        set -euo pipefail
+
+        shopt -s nullglob
+        svgs=("$BADGES_DIR"/*.svg)
+        if (( ${#svgs[@]} == 0 )); then
+          echo "No badge SVGs in $BADGES_DIR - nothing to push."
+          exit 0
+        fi
+
+        SRC_SLUG="${SOURCE_REF//\//_}"
+        echo "Publishing badges for ref '$SOURCE_REF' -> '$BADGES_BRANCH:$SRC_SLUG/'"
+
+        REMOTE="https://x-access-token:${GH_TOKEN}@github.com/${GITHUB_REPOSITORY}.git"
+        WORKDIR="$(mktemp -d)"
+        SRC_DIR="$PWD/$BADGES_DIR"
+
+        cd "$WORKDIR"
+        git init -q -b "$BADGES_BRANCH" .
+        git config user.name  "github-actions[bot]"
+        git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+        git remote add origin "$REMOTE"
+
+        if git fetch --depth 1 origin "$BADGES_BRANCH" 2>/dev/null; then
+          git reset --hard "origin/$BADGES_BRANCH"
+        else
+          echo "Badges branch does not exist yet; bootstrapping."
+          printf '# CI-generated badges\n\nThis branch is written by CI and holds SVG badges per source branch under `<branch>/`. Do not commit manually.\n' > README.md
+          git add README.md
+          git commit -q -m "Initialise badges branch"
+        fi
+
+        mkdir -p "$SRC_SLUG"
+        cp "${svgs[@]}" "$SRC_SLUG/"
+
+        git add "$SRC_SLUG/"
+        if git diff --cached --quiet; then
+          echo "Badges unchanged; nothing to commit."
+          exit 0
+        fi
+
+        git commit -q -m "Update badges for ${SOURCE_REF} [skip ci]"
+
+        for attempt in 1 2 3 4 5; do
+          if git push origin "HEAD:$BADGES_BRANCH"; then
+            echo "Pushed badges (attempt $attempt)."
+            exit 0
+          fi
+          echo "Push failed on attempt $attempt; refreshing and retrying."
+          git fetch --depth 1 origin "$BADGES_BRANCH"
+          if ! git rebase "origin/$BADGES_BRANCH"; then
+            git rebase --abort || true
+            git reset --hard "origin/$BADGES_BRANCH"
+            mkdir -p "$SRC_SLUG"
+            cp "${svgs[@]}" "$SRC_SLUG/"
+            git add "$SRC_SLUG/"
+            if git diff --cached --quiet; then
+              echo "Badges match remote after refresh; nothing to push."
+              exit 0
+            fi
+            git commit -q -m "Update badges for ${SOURCE_REF} [skip ci]"
+          fi
+          sleep $(( attempt * 2 ))
+        done
+
+        echo "::error::Failed to push badges after 5 attempts."
+        exit 1

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -93,16 +93,16 @@ jobs:
             addpath(genpath( "tools" ));
             testToolboxNoCloud()
 
-      # Only commit badges on pull requests from the same repository. The action
-      # pushes to the PR head branch, which is not protected. Pushing on `push`
-      # events would target the protected `main` branch and be rejected
-      # (GH006: "Changes must be made through a pull request"), failing the job.
-      - name: Commit SVG badges if updated
-        if: always() && github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository
-        uses: ehennestad/matbox-actions/push-badges@8fe220fbaec9e119ec5081eb917c8e016e275f1e # v1
+      # Push freshly-generated SVG badges to the dedicated `badges` branch under
+      # `<source-ref>/`, rather than committing them onto the working branch.
+      # This keeps PR diffs clean and lets `main` runs refresh their own badges
+      # (which the old flow could not do, because `main` is protection-gated).
+      - name: Push SVG badges to badges branch
+        if: always() && (github.event_name == 'push' || (github.event_name == 'pull_request' && !github.event.pull_request.draft && github.event.pull_request.head.repo.full_name == github.repository))
+        uses: ./.github/actions/push-badges-to-branch
         with:
-          pr-ref: ${{ github.event.pull_request.head.ref }}
-          pr-repo: ${{ github.event.pull_request.head.repo.full_name }}
+          source-ref: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.ref || github.ref_name }}
+          token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Upload code coverage report to Codecov
         uses: codecov/codecov-action@b9fd7d16f6d7d1b5d2bec1a2887e65ceed900238 # v4

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # NDI
-[![MATLAB Tests](.github/badges/tests.svg)](https://github.com/VH-Lab/NDI-matlab/actions/workflows/run_tests.yml)
+[![MATLAB Tests](https://raw.githubusercontent.com/VH-Lab/NDI-matlab/badges/main/tests.svg)](https://github.com/VH-Lab/NDI-matlab/actions/workflows/run-tests.yml)
 [![codecov](https://codecov.io/gh/VH-Lab/NDI-matlab/branch/main/graph/badge.svg?token=5K3PA9KOT9)](https://codecov.io/gh/VH-Lab/NDI-matlab)
-[![MATLAB Code Issues](.github/badges/code_issues.svg)](https://github.com/VH-Lab/NDI-matlab/security/code-scanning)
+[![MATLAB Code Issues](https://raw.githubusercontent.com/VH-Lab/NDI-matlab/badges/main/code_issues.svg)](https://github.com/VH-Lab/NDI-matlab/security/code-scanning)
 [![Maintenance](https://img.shields.io/badge/Maintained%3F-yes-green.svg)](https://gitHub.com/VH-Lab/NDI-matlab/graphs/commit-activity)
 
 Neuroscience Data Interface - A means of specifying and accessing neuroscience data and analyses


### PR DESCRIPTION
## Summary

The `run-tests` workflow previously committed generated SVG badges (`.github/badges/*.svg`) onto the PR head branch, and skipped the badge step entirely on pushes to `main` because `main` is protection-gated (GH006). That meant:

- Every PR carried noisy per-run badge commits, which distracted human reviewers and confused AI agents interpreting the log.
- The `main` badges never refreshed on merge, so the README values could drift from reality.

This PR pushes generated badges to a separate `badges` branch instead, laid out as `<sanitised-source-ref>/*.svg`. Since each source ref writes to its own directory, concurrent runs on different refs cannot conflict.

## What changed

- New repo-local composite action `.github/actions/push-badges-to-branch` — holds the shared shell that pushes badges to the `badges` branch. Lazily creates the branch on first run and retries with rebase on push races.
- `.github/workflows/run-tests.yml` — replaces the `matbox-actions/push-badges` step with the new composite action, and enables it for pushes to `main` too (safe now that we're not writing to a protected branch).
- `README.md` — badges now reference `https://raw.githubusercontent.com/VH-Lab/NDI-matlab/badges/main/tests.svg` (and `code_issues.svg`) instead of the in-tree paths.

## Verification

- Local `yaml.safe_load` on the action and workflow succeeds.
- `bash -n` on the embedded shell script succeeds.
- The `badges` branch does not yet exist; the action bootstraps it as an orphan on first run, so no manual pre-seed step is required.

## First-run notes

- Camo (GitHub's image proxy) caches badge images from `raw.githubusercontent.com` for a few minutes. Fresh badges may take a moment to appear in the rendered README on `main`.
- On this branch's PR run itself, badges will land under `claude_ci-badge-pushing-strategy-gmmxt8/` in the `badges` branch (paths are slash-sanitised).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AZM4mnZNa49TqRvzXZpRC5

---
_Generated by [Claude Code](https://claude.ai/code/session_01AZM4mnZNa49TqRvzXZpRC5)_