### PR TITLE
Fix #945: stop destroying files.series_info after download, and test the round trip that found it

### DIFF
--- a/src/ndi/+ndi/+cloud/+sync/+internal/updateFileInfoForLocalFiles.m
+++ b/src/ndi/+ndi/+cloud/+sync/+internal/updateFileInfoForLocalFiles.m
@@ -18,6 +18,25 @@ function document = updateFileInfoForLocalFiles(document, fileDirectory)
 
     if document.has_files()
         originalFileInfo = document.document_properties.files.file_info;
+
+        % reset_file_info clears files.series_info along with file_info -- see
+        % did.document/reset_file_info, "A series' per-instance record is reset
+        % with the rest". The loop below only restores file_info, so without
+        % this a downloaded document loses the per-series record entirely and
+        % reports zero members for a populated series. Silently: isFileSeries
+        % reads files.file_series, the class declaration, which the reset
+        % leaves alone, so only seriesCount notices and it returns 0 rather
+        % than erroring. See VH-Lab/NDI-matlab#945.
+        %
+        % Carried across verbatim. The record holds name, count, n_present and
+        % source_root; its ingest_locations were already emptied on the way
+        % into storage, and nothing here re-ingests members, so there is
+        % nothing to recompute.
+        hasSeriesInfo = isfield(document.document_properties.files, 'series_info');
+        if hasSeriesInfo
+            originalSeriesInfo = document.document_properties.files.series_info;
+        end
+
         document = document.reset_file_info();
     
         for i = 1:numel(originalFileInfo)
@@ -31,6 +50,10 @@ function document = updateFileInfoForLocalFiles(document, fileDirectory)
                 warning('Local file does not exist for document "%s"', ...
                     document.document_properties.base.id)
             end
+        end
+
+        if hasSeriesInfo
+            document = document.setproperties('files.series_info', originalSeriesInfo);
         end
     end
 end

--- a/tests/+ndi/+unittest/+cloud/FileSeriesRoundTripTest.m
+++ b/tests/+ndi/+unittest/+cloud/FileSeriesRoundTripTest.m
@@ -239,6 +239,16 @@ classdef FileSeriesRoundTripTest < matlab.unittest.TestCase
                 'the series document did not come back from the cloud');
             remoteDoc = remoteDocs{1};
 
+            % On failure, show what actually came back rather than just the
+            % number that did not match: whether series_info still has its
+            % count and n_present fields, what else survived beside them, and
+            % whether ingest_locations came back as [] or as a struct. That is
+            % the difference between the server dropping fields and the JSON
+            % round trip reshaping them. See VH-Lab/NDI-matlab#945, and
+            % ndi.unittest.database.TestDocumentSeriesJsonRoundTrip for the
+            % no-network half of the same question.
+            testCase.onFailure(@() disp(remoteDoc.document_properties.files));
+
             % The series declaration has to survive serialization, not just
             % the bytes of the manifest.
             testCase.verifyTrue(remoteDoc.isFileSeries('chunkdata.bin'), ...

--- a/tests/+ndi/+unittest/+cloud/FileSeriesRoundTripTest.m
+++ b/tests/+ndi/+unittest/+cloud/FileSeriesRoundTripTest.m
@@ -5,22 +5,31 @@ classdef FileSeriesRoundTripTest < matlab.unittest.TestCase
 % uploads it, and reads it back. This is the acceptance test for the file
 % series work tracked in VH-Lab/DID-matlab#173.
 %
-% It does not pass yet, and is written so that it reports Incomplete rather
-% than Failed until each piece lands. Three things are outstanding, and the
-% assumptions below name them individually so the reason a run skipped is the
-% reason, not a guess:
+% It is written so that what cannot work yet reports Incomplete rather than
+% Failed, and so that a skip names its own reason rather than leaving it to be
+% guessed. Of the three things that were outstanding when it was written:
 %
-%   1. ndi.document has no series methods. It re-implements DID's file API
-%      (add_file, is_in_file_list, current_file_list, remove_file,
-%      reset_file_info) rather than inheriting it, so did.document gaining
-%      addFileSeries in VH-Lab/DID-matlab#178 does not give ndi.document one.
-%   2. Member ingestion is deferred: addFileSeries records where members are
-%      but nothing yet copies them into FileDir/<uid> or gives them rows in
-%      the files table, so there is nothing to upload for a member.
-%   3. ndi-cloud-node does not enumerate series members when signing URLs.
+%   1. DONE. ndi.document had no series methods -- it re-implemented DID's
+%      file API rather than inheriting it, so did.document gaining
+%      addFileSeries in VH-Lab/DID-matlab#178 gave ndi.document nothing.
+%      VH-Lab/NDI-matlab#940 made it a subclass, and the class-level
+%      assumption below now opens.
+%   2. OPEN. Member ingestion is deferred: addFileSeries records where
+%      members are but nothing yet copies them into FileDir/<uid> or gives
+%      them rows in the files table, so there is nothing to upload for a
+%      member. testMembersSurviveTheRoundTrip skips on this.
+%   3. OPEN. ndi-cloud-node does not enumerate series members when signing
+%      URLs.
 %
-% The manifest half of the round trip is testable ahead of (2) and (3),
-% because the manifest is an ordinary document file and travels like one.
+% The manifest half is testable ahead of (2) and (3), because the manifest is
+% an ordinary document file and travels like one. Note what that does and does
+% not buy: testManifestSurvivesTheRoundTrip, testDocumentReportsItsSeries and
+% testCurrentFileListDoesNotExpandTheSeries all upload and then assert against
+% LocalDataset, which is never re-downloaded, so they show the cloud ACCEPTS a
+% document carrying a series manifest and nothing more. Only
+% testManifestSurvivesADownloadFromTheCloud reads the series back out of the
+% cloud, and it is the one that would catch a manifest dropped, renamed or
+% altered in transit.
 
     properties (Constant)
         DatasetNamePrefix = 'NDI_UNITTEST_FILE_SERIES_';
@@ -184,5 +193,81 @@ classdef FileSeriesRoundTripTest < matlab.unittest.TestCase
                     sprintf('member %d came back with different bytes', i));
             end
         end
+
+        function testManifestSurvivesADownloadFromTheCloud(testCase)
+            % The genuine round trip, and the only test here that reads the
+            % series back out of the cloud rather than out of the local
+            % dataset it was built in.
+            %
+            % The three tests above upload and then assert against
+            % testCase.LocalDataset, which is never re-downloaded. That
+            % establishes the cloud ACCEPTS a document carrying a series
+            % manifest, which is worth knowing but is not a round trip: a
+            % server that quietly dropped the manifest file, renamed it, or
+            % returned different bytes would pass all three.
+            %
+            % This one downloads the dataset into a fresh folder and reads the
+            % manifest from the downloaded copy, so the uids it checks are the
+            % ones that actually made the journey. It needs SyncFiles so the
+            % file contents come down and not just the document records.
+            %
+            % Members are still out of reach (see the class header, item 2),
+            % so this covers the manifest half only -- which is the half that
+            % is testable today, and the half a series reader hits first.
+
+            import matlab.unittest.fixtures.TemporaryFolderFixture
+
+            % The local manifest, to compare against.
+            q = ndi.query('base.name', 'exact_string', 'test_series_doc');
+            localDocs = testCase.LocalDataset.database_search(q);
+            testCase.fatalAssertNumElements(localDocs, 1);
+            localFobj = testCase.LocalDataset.database_openbinarydoc(localDocs{1}, 'chunkdata.bin');
+            localManifest = did.file.readSeriesManifest(localFobj.fullpathfilename);
+            testCase.LocalDataset.database_closebinarydoc(localFobj);
+
+            % Two steps rather than chaining off applyFixture, matching the
+            % setup above; indexing into a method's return value is not
+            % something to rely on here.
+            downloadFixture = testCase.applyFixture(TemporaryFolderFixture);
+            downloaded = ndi.cloud.downloadDataset(testCase.DatasetID, downloadFixture.Folder, ...
+                'SyncFiles', true, 'Verbose', false);
+            testCase.fatalAssertNotEmpty(downloaded, ...
+                'downloadDataset returned nothing for the uploaded dataset');
+
+            remoteDocs = downloaded.database_search(q);
+            testCase.fatalAssertNumElements(remoteDocs, 1, ...
+                'the series document did not come back from the cloud');
+            remoteDoc = remoteDocs{1};
+
+            % The series declaration has to survive serialization, not just
+            % the bytes of the manifest.
+            testCase.verifyTrue(remoteDoc.isFileSeries('chunkdata.bin'), ...
+                'the downloaded document no longer reports chunkdata.bin as a series');
+            [n, nPresent] = remoteDoc.seriesCount('chunkdata.bin');
+            testCase.verifyEqual(n, testCase.MemberCount, ...
+                'downloaded series declares a different member count');
+            testCase.verifyEqual(nPresent, testCase.MemberCount, ...
+                'downloaded series lost members from its manifest slots');
+
+            % And the members must still not be expanded into the file list
+            % on the far side -- the bloat this design exists to avoid would
+            % otherwise reappear on every reader that downloads a dataset.
+            fl = remoteDoc.current_file_list();
+            testCase.verifyTrue(ismember('chunkdata.bin', fl));
+            testCase.verifyFalse(ismember('chunkdata.bin_1', fl), ...
+                'members were expanded into the downloaded file list');
+
+            % The manifest bytes themselves.
+            remoteFobj = downloaded.database_openbinarydoc(remoteDoc, 'chunkdata.bin');
+            remoteManifest = did.file.readSeriesManifest(remoteFobj.fullpathfilename);
+            downloaded.database_closebinarydoc(remoteFobj);
+
+            testCase.verifyEqual(remoteManifest.count, testCase.MemberCount, ...
+                'downloaded manifest reports a different member count');
+            testCase.verifyEqual(remoteManifest.uids, localManifest.uids, ...
+                ['downloaded manifest uids differ from the ones uploaded; ' ...
+                 'a member would resolve to the wrong file']);
+        end
+
     end
 end

--- a/tests/+ndi/+unittest/+cloud/FileSeriesRoundTripTest.m
+++ b/tests/+ndi/+unittest/+cloud/FileSeriesRoundTripTest.m
@@ -37,6 +37,13 @@ classdef FileSeriesRoundTripTest < matlab.unittest.TestCase
     end
 
     properties
+        % Every cloud test in this suite carries a narrative, so a failure
+        % reads as a sequence of steps and a structured JSON report rather
+        % than a bare number. The audience for these failures is often not a
+        % MATLAB user -- NDI-matlab#945 is being handed to whoever maintains
+        % ndi-cloud-node -- and "0 where 4 was expected" is not something they
+        % can act on. See ndi.unittest.cloud.APIMessage.
+        Narrative (1,:) string
         DatasetID (1,1) string = missing
         LocalDataset
         MemberPaths (1,:) cell = {}
@@ -68,6 +75,11 @@ classdef FileSeriesRoundTripTest < matlab.unittest.TestCase
     methods (TestMethodSetup)
         function setupLocalDatasetAndCloud(testCase)
             import matlab.unittest.fixtures.TemporaryFolderFixture
+
+            narrative = "Begin FileSeriesRoundTripTest setup.";
+            narrative(end+1) = "Creating a local dataset and " + ...
+                testCase.MemberCount + " series members on disk.";
+
             tempFolder = testCase.applyFixture(TemporaryFolderFixture);
             testCase.LocalDataset = ndi.dataset.dir('test_series_ds', tempFolder.Folder);
 
@@ -92,22 +104,38 @@ classdef FileSeriesRoundTripTest < matlab.unittest.TestCase
             doc = doc.addFileSeries('chunkdata.bin', testCase.MemberPaths);
             testCase.LocalDataset.database_add(doc);
             testCase.SeriesDocId = doc.id();
+            narrative(end+1) = "Added document 'test_series_doc' (id " + ...
+                string(doc.id()) + ") with file series 'chunkdata.bin' " + ...
+                "declaring " + testCase.MemberCount + " members.";
 
             unique_name = testCase.DatasetNamePrefix + string(did.ido.unique_id());
+            narrative(end+1) = "Creating cloud dataset named " + unique_name + ".";
             [b, cloudId] = ndi.cloud.api.datasets.createDataset(struct("name", unique_name));
-            testCase.fatalAssertTrue(b, "Failed to create cloud dataset.");
+            msg = ndi.unittest.cloud.APIMessage(narrative, b, cloudId, ...
+                matlab.net.http.ResponseMessage.empty, "datasets.createDataset");
+            testCase.fatalAssertTrue(b, "Failed to create cloud dataset. " + msg);
             testCase.DatasetID = cloudId;
+            narrative(end+1) = "Cloud dataset id is " + string(cloudId) + ".";
 
             remoteDoc = ndi.cloud.internal.createRemoteDatasetDoc(cloudId, testCase.LocalDataset);
             testCase.LocalDataset.database_add(remoteDoc);
 
+            narrative(end+1) = "Uploading the dataset (documents are batched " + ...
+                "as one JSON array by zip_documents_for_upload).";
             successUpload = ndi.cloud.uploadDataset(testCase.LocalDataset);
-            testCase.fatalAssertTrue(successUpload, "Failed to upload test dataset.");
+            msg = ndi.unittest.cloud.APIMessage(narrative, successUpload, ...
+                successUpload, matlab.net.http.ResponseMessage.empty, ...
+                "ndi.cloud.uploadDataset");
+            testCase.fatalAssertTrue(successUpload, ...
+                "Failed to upload test dataset. " + msg);
 
             % Server-side zip extraction has to finish before anything reads
             % the per-file objects back (issue #755).
+            narrative(end+1) = "Waiting for server-side bulk upload extraction to finish.";
             ndi.cloud.api.files.waitForAllBulkUploads(testCase.DatasetID);
+            narrative(end+1) = "Setup complete; the series is now in the cloud.";
 
+            testCase.Narrative = narrative;
             testCase.addTeardown(@() testCase.cleanupCloudDataset());
         end
     end
@@ -125,6 +153,11 @@ classdef FileSeriesRoundTripTest < matlab.unittest.TestCase
         function testManifestSurvivesTheRoundTrip(testCase)
             % The manifest is an ordinary document file, so this half works
             % before member ingestion and before the server knows about series.
+            narrative = testCase.Narrative;
+            narrative(end+1) = "Begin testManifestSurvivesTheRoundTrip.";
+            narrative(end+1) = "NOTE: this test reads the LOCAL dataset, not the cloud. " + ...
+                "It shows the upload was accepted, not that anything came back.";
+
             q = ndi.query('base.name', 'exact_string', 'test_series_doc');
             docs = testCase.LocalDataset.database_search(q);
             testCase.fatalAssertNumElements(docs, 1);
@@ -134,43 +167,78 @@ classdef FileSeriesRoundTripTest < matlab.unittest.TestCase
             m = did.file.readSeriesManifest(manifestPath);
             testCase.LocalDataset.database_closebinarydoc(fobj);
 
-            testCase.verifyEqual(m.count, testCase.MemberCount);
+            narrative(end+1) = "Read the local manifest; it reports " + m.count + " members.";
+            msg = ndi.unittest.cloud.APIMessage(narrative, true, m, ...
+                matlab.net.http.ResponseMessage.empty, "local read of chunkdata.bin");
+
+            testCase.verifyEqual(m.count, testCase.MemberCount, ...
+                "local manifest member count is wrong. " + msg);
             for i = 1:testCase.MemberCount
                 testCase.verifyNotEmpty(m.uids{i}, ...
-                    sprintf('member %d should have a uid in the manifest', i));
+                    "member " + i + " has no uid in the manifest. " + msg);
             end
+            testCase.Narrative = narrative;
         end
 
         function testDocumentReportsItsSeries(testCase)
+            narrative = testCase.Narrative;
+            narrative(end+1) = "Begin testDocumentReportsItsSeries.";
+            narrative(end+1) = "Reading the LOCAL dataset. This is the control for " + ...
+                "NDI-matlab#945: the same query against the DOWNLOADED dataset returns 0.";
+
             q = ndi.query('base.name', 'exact_string', 'test_series_doc');
             docs = testCase.LocalDataset.database_search(q);
             testCase.fatalAssertNumElements(docs, 1);
             doc = docs{1};
 
-            testCase.verifyTrue(doc.isFileSeries('chunkdata.bin'));
             [n, nPresent] = doc.seriesCount('chunkdata.bin');
-            testCase.verifyEqual(n, testCase.MemberCount);
-            testCase.verifyEqual(nPresent, testCase.MemberCount);
+            narrative(end+1) = "Local document reports count=" + n + ", n_present=" + nPresent + ".";
+            msg = ndi.unittest.cloud.APIMessage(narrative, true, ...
+                doc.document_properties.files, ...
+                matlab.net.http.ResponseMessage.empty, "local database_search");
+
+            testCase.verifyTrue(doc.isFileSeries('chunkdata.bin'), ...
+                "local document does not report chunkdata.bin as a series. " + msg);
+            testCase.verifyEqual(n, testCase.MemberCount, ...
+                "local series count is wrong. " + msg);
+            testCase.verifyEqual(nPresent, testCase.MemberCount, ...
+                "local series present-count is wrong. " + msg);
+            testCase.Narrative = narrative;
         end
 
         function testCurrentFileListDoesNotExpandTheSeries(testCase)
             % A 28,000-member series must not materialise 28,000 names here --
             % that is the bloat the manifest exists to remove, reappearing one
             % layer up. Called out in VH-Lab/DID-matlab#173.
+            narrative = testCase.Narrative;
+            narrative(end+1) = "Begin testCurrentFileListDoesNotExpandTheSeries.";
+
             q = ndi.query('base.name', 'exact_string', 'test_series_doc');
             docs = testCase.LocalDataset.database_search(q);
             fl = docs{1}.current_file_list();
+            narrative(end+1) = "current_file_list returned " + numel(fl) + " entries.";
+            msg = ndi.unittest.cloud.APIMessage(narrative, true, fl, ...
+                matlab.net.http.ResponseMessage.empty, "local current_file_list");
 
             testCase.verifyTrue(ismember('chunkdata.bin', fl), ...
-                'the manifest itself is an ordinary file and should be listed');
+                "the manifest itself is an ordinary file and should be listed. " + msg);
             testCase.verifyFalse(ismember('chunkdata.bin_1', fl), ...
-                'members must not be expanded into the file list');
+                "members must not be expanded into the file list. " + msg);
+            testCase.Narrative = narrative;
         end
 
         function testMembersSurviveTheRoundTrip(testCase)
             % The whole point. Needs member ingestion (DID) and series-aware
             % URL signing (ndi-cloud-node); until both land this skips rather
             % than fails, and becomes live on its own once they do.
+            narrative = testCase.Narrative;
+            narrative(end+1) = "Begin testMembersSurviveTheRoundTrip.";
+            narrative(end+1) = "This test skips until member ingestion lands " + ...
+                "(VH-Lab/DID-matlab#173). The gate below is a LOCAL check: nothing " + ...
+                "copies members into FileDir/<uid>, so there is nothing to upload " + ...
+                "and no cloud change can open it.";
+            testCase.Narrative = narrative;
+
             q = ndi.query('base.name', 'exact_string', 'test_series_doc');
             docs = testCase.LocalDataset.database_search(q);
             doc = docs{1};
@@ -217,6 +285,11 @@ classdef FileSeriesRoundTripTest < matlab.unittest.TestCase
 
             import matlab.unittest.fixtures.TemporaryFolderFixture
 
+            narrative = testCase.Narrative;
+            narrative(end+1) = "Begin testManifestSurvivesADownloadFromTheCloud.";
+            narrative(end+1) = "This is the only test here that reads the series back " + ...
+                "OUT of the cloud. The three above assert against the local dataset.";
+
             % The local manifest, to compare against.
             q = ndi.query('base.name', 'exact_string', 'test_series_doc');
             localDocs = testCase.LocalDataset.database_search(q);
@@ -224,19 +297,30 @@ classdef FileSeriesRoundTripTest < matlab.unittest.TestCase
             localFobj = testCase.LocalDataset.database_openbinarydoc(localDocs{1}, 'chunkdata.bin');
             localManifest = did.file.readSeriesManifest(localFobj.fullpathfilename);
             testCase.LocalDataset.database_closebinarydoc(localFobj);
+            narrative(end+1) = "Local manifest before download: count=" + ...
+                localManifest.count + ".";
 
             % Two steps rather than chaining off applyFixture, matching the
             % setup above; indexing into a method's return value is not
             % something to rely on here.
             downloadFixture = testCase.applyFixture(TemporaryFolderFixture);
+            narrative(end+1) = "Downloading dataset " + testCase.DatasetID + ...
+                " with SyncFiles=true into a fresh folder.";
             downloaded = ndi.cloud.downloadDataset(testCase.DatasetID, downloadFixture.Folder, ...
                 'SyncFiles', true, 'Verbose', false);
+            msg = ndi.unittest.cloud.APIMessage(narrative, ~isempty(downloaded), ...
+                "downloadDataset returned an ndi.dataset", ...
+                matlab.net.http.ResponseMessage.empty, "ndi.cloud.downloadDataset");
             testCase.fatalAssertNotEmpty(downloaded, ...
-                'downloadDataset returned nothing for the uploaded dataset');
+                "downloadDataset returned nothing for the uploaded dataset. " + msg);
 
             remoteDocs = downloaded.database_search(q);
+            narrative(end+1) = "Downloaded dataset returned " + numel(remoteDocs) + ...
+                " document(s) matching base.name 'test_series_doc'.";
+            msg = ndi.unittest.cloud.APIMessage(narrative, true, numel(remoteDocs), ...
+                matlab.net.http.ResponseMessage.empty, "downloaded database_search");
             testCase.fatalAssertNumElements(remoteDocs, 1, ...
-                'the series document did not come back from the cloud');
+                "the series document did not come back from the cloud. " + msg);
             remoteDoc = remoteDocs{1};
 
             % On failure, show what actually came back rather than just the
@@ -249,15 +333,31 @@ classdef FileSeriesRoundTripTest < matlab.unittest.TestCase
             % no-network half of the same question.
             testCase.onFailure(@() disp(remoteDoc.document_properties.files));
 
+            [n, nPresent] = remoteDoc.seriesCount('chunkdata.bin');
+            hasSeriesInfo = isfield(remoteDoc.document_properties.files, 'series_info') && ...
+                ~isempty(remoteDoc.document_properties.files.series_info);
+            narrative(end+1) = "Downloaded document: files.series_info present = " + ...
+                string(hasSeriesInfo) + ", seriesCount reports count=" + n + ...
+                ", n_present=" + nPresent + " (expected " + testCase.MemberCount + ").";
+            narrative(end+1) = "If series_info is absent, the server dropped the whole " + ...
+                "per-series record; if present with zeros, it kept the entry and zeroed " + ...
+                "the numbers. seriesCount returns 0/0 for BOTH, which is why the struct " + ...
+                "is reported below. See VH-Lab/NDI-matlab#945.";
+            narrative(end+1) = "Note isFileSeries reads files.file_series (the CLASS " + ...
+                "declaration, from the schema), not files.series_info, so it can pass " + ...
+                "while the instance record is gone.";
+            msg = ndi.unittest.cloud.APIMessage(narrative, true, ...
+                remoteDoc.document_properties.files, ...
+                matlab.net.http.ResponseMessage.empty, "downloaded document files struct");
+
             % The series declaration has to survive serialization, not just
             % the bytes of the manifest.
             testCase.verifyTrue(remoteDoc.isFileSeries('chunkdata.bin'), ...
-                'the downloaded document no longer reports chunkdata.bin as a series');
-            [n, nPresent] = remoteDoc.seriesCount('chunkdata.bin');
+                "the downloaded document no longer reports chunkdata.bin as a series. " + msg);
             testCase.verifyEqual(n, testCase.MemberCount, ...
-                'downloaded series declares a different member count');
+                "downloaded series declares a different member count. " + msg);
             testCase.verifyEqual(nPresent, testCase.MemberCount, ...
-                'downloaded series lost members from its manifest slots');
+                "downloaded series lost members from its manifest slots. " + msg);
 
             % And the members must still not be expanded into the file list
             % on the far side -- the bloat this design exists to avoid would
@@ -272,11 +372,16 @@ classdef FileSeriesRoundTripTest < matlab.unittest.TestCase
             remoteManifest = did.file.readSeriesManifest(remoteFobj.fullpathfilename);
             downloaded.database_closebinarydoc(remoteFobj);
 
+            narrative(end+1) = "Downloaded manifest reports count=" + remoteManifest.count + ".";
+            msg = ndi.unittest.cloud.APIMessage(narrative, true, remoteManifest, ...
+                matlab.net.http.ResponseMessage.empty, "downloaded chunkdata.bin manifest");
+
             testCase.verifyEqual(remoteManifest.count, testCase.MemberCount, ...
-                'downloaded manifest reports a different member count');
+                "downloaded manifest reports a different member count. " + msg);
             testCase.verifyEqual(remoteManifest.uids, localManifest.uids, ...
-                ['downloaded manifest uids differ from the ones uploaded; ' ...
-                 'a member would resolve to the wrong file']);
+                "downloaded manifest uids differ from the ones uploaded; " + ...
+                "a member would resolve to the wrong file. " + msg);
+            testCase.Narrative = narrative;
         end
 
     end

--- a/tests/+ndi/+unittest/+database/TestDocumentSeriesJsonRoundTrip.m
+++ b/tests/+ndi/+unittest/+database/TestDocumentSeriesJsonRoundTrip.m
@@ -129,5 +129,55 @@ classdef TestDocumentSeriesJsonRoundTrip < matlab.unittest.TestCase
             testCase.verifyEqual(nPresent, testCase.MemberCount);
         end
 
+
+        function testSeriesSurvivesTheBatchEncodingTheUploadActuallyUses(testCase)
+            % The tests above encode ONE properties struct. The upload does
+            % not. ndi.cloud.upload.internal.zip_documents_for_upload builds a
+            % CELL ARRAY of every document's properties and encodes that in
+            % one call:
+            %
+            %   document_properties_array = cellfun(@(x) x.document_properties, ...
+            %       documentList, 'UniformOutput', false);
+            %   jsonStr = did.datastructures.jsonencodenan(document_properties_array);
+            %
+            % A cell array becomes a JSON array of objects, and jsondecode
+            % gives back a struct array when the objects agree on their fields
+            % and a cell array when they do not. That reshaping is a real
+            % opportunity to lose a nested struct, and none of the single
+            % document tests above would see it. The test dataset uploads three
+            % documents of mixed type, so mix them here too.
+            seriesDoc = testCase.makeSeriesDocument();
+            otherA = ndi.document('demoNDI', 'base.name', 'other_a', ...
+                'base.session_id', did.ido.unique_id());
+            otherB = ndi.document('demoNDI', 'base.name', 'other_b', ...
+                'base.session_id', did.ido.unique_id());
+
+            documentList = {otherA, seriesDoc, otherB};
+            propsArray = cellfun(@(x) did.document.stripSeriesIngestLocations( ...
+                x.document_properties), documentList, 'UniformOutput', false);
+
+            encoded = did.datastructures.jsonencodenan(propsArray);
+            decoded = jsondecode(ndi.util.rehydrateJSONNanNull(encoded));
+            if isstruct(decoded), decoded = num2cell(decoded); end
+
+            testCase.fatalAssertEqual(numel(decoded), 3, ...
+                'the batch did not decode back into three documents');
+
+            rebuilt = cellfun(@(x) ndi.document(x), decoded, 'UniformOutput', false);
+            names = cellfun(@(d) string(d.document_properties.base.name), rebuilt);
+            k = find(names == "json_round_trip_doc", 1);
+            testCase.fatalAssertNotEmpty(k, ...
+                'the series document did not survive the batch round trip at all');
+
+            testCase.onFailure(@() disp(rebuilt{k}.document_properties.files));
+            testCase.verifyTrue(rebuilt{k}.isFileSeries('chunkdata.bin'), ...
+                'the series declaration did not survive the batch encoding');
+            [n, nPresent] = rebuilt{k}.seriesCount('chunkdata.bin');
+            testCase.verifyEqual(n, testCase.MemberCount, ...
+                'count did not survive the batch encoding the upload uses');
+            testCase.verifyEqual(nPresent, testCase.MemberCount, ...
+                'n_present did not survive the batch encoding the upload uses');
+        end
+
     end
 end

--- a/tests/+ndi/+unittest/+database/TestDocumentSeriesJsonRoundTrip.m
+++ b/tests/+ndi/+unittest/+database/TestDocumentSeriesJsonRoundTrip.m
@@ -1,0 +1,133 @@
+classdef TestDocumentSeriesJsonRoundTrip < matlab.unittest.TestCase
+    % Does a file series survive the JSON encode/decode the cloud upload uses?
+    %
+    % This suite exists to split one specific question in VH-Lab/NDI-matlab#945:
+    % a document uploaded to the cloud comes back DECLARED BUT EMPTY --
+    % isFileSeries still says yes, but seriesCount returns 0 where 4 was
+    % uploaded. It reproduces identically against prod and against dev, so it
+    % is not something the newer API fixes.
+    %
+    % Three things were ruled out by reading: the download-side rebuild
+    % (did.document's constructor guards its reset with ~made_from_struct, so
+    % the struct path preserves series_info verbatim), a document cache
+    % masking a local failure (did.database caches FILES, not documents), and
+    % jsonencodenan itself (a thin wrapper around jsonencode). That leaves the
+    % encode/decode pair or the server.
+    %
+    % These tests are the client half of that split, and they need no
+    % credentials and no network, so they run in the fast workflow on every
+    % PR rather than only in Cloud CI:
+    %
+    %   FAIL -> the loss is ours, in encode/decode, and the fix is local
+    %   PASS -> the client round trip is clean and the server is dropping or
+    %           defaulting the fields, in both environments
+    %
+    % testStoredFormSurvivesTheJsonRoundTrip is the one that matters most: it
+    % strips ingest locations first, which is the form the database stores and
+    % therefore the form the upload actually ships.
+
+    properties (Constant)
+        MemberCount = 4;
+    end
+
+    properties
+        MemberPaths (1,:) cell = {}
+    end
+
+    methods (TestMethodSetup)
+        function setupMembers(testCase)
+            testCase.applyFixture(matlab.unittest.fixtures.WorkingFolderFixture);
+            memberDir = fullfile(pwd, 'level0');
+            mkdir(memberDir);
+            testCase.MemberPaths = cell(1, testCase.MemberCount);
+            for i = 1:testCase.MemberCount
+                p = fullfile(memberDir, sprintf('chunk_%04d.bin', i));
+                fid = fopen(p, 'w');
+                fwrite(fid, uint8(mod((1:16) * i, 251)), 'uint8');
+                fclose(fid);
+                testCase.MemberPaths{i} = p;
+            end
+        end
+    end
+
+    methods (Access = private)
+        function doc = makeSeriesDocument(testCase)
+            doc = ndi.document('demoNDISeries', ...
+                'base.name', 'json_round_trip_doc', ...
+                'demoNDISeries.value', 1, ...
+                'base.session_id', did.ido.unique_id());
+            doc = doc.addFileSeries('chunkdata.bin', testCase.MemberPaths);
+        end
+
+        function rebuilt = jsonRoundTrip(~, props)
+            % Exactly the pair the cloud path uses: the upload encodes with
+            % did.datastructures.jsonencodenan, the download rehydrates and
+            % decodes before handing the struct to ndi.document.
+            encoded  = did.datastructures.jsonencodenan(props);
+            decoded  = jsondecode(ndi.util.rehydrateJSONNanNull(encoded));
+            rebuilt  = ndi.document(decoded);
+        end
+    end
+
+    methods (Test)
+
+        function testTheDocumentStartsWithFourMembers(testCase)
+            % Sanity: if this fails, nothing below means anything.
+            doc = testCase.makeSeriesDocument();
+            [n, nPresent] = doc.seriesCount('chunkdata.bin');
+            testCase.verifyEqual(n, testCase.MemberCount);
+            testCase.verifyEqual(nPresent, testCase.MemberCount);
+        end
+
+        function testSeriesCountSurvivesTheJsonRoundTrip(testCase)
+            doc = testCase.makeSeriesDocument();
+            rebuilt = testCase.jsonRoundTrip(doc.document_properties);
+
+            testCase.onFailure(@() disp(rebuilt.document_properties.files));
+            testCase.verifyTrue(rebuilt.isFileSeries('chunkdata.bin'), ...
+                'the series declaration did not survive encode/decode');
+            [n, nPresent] = rebuilt.seriesCount('chunkdata.bin');
+            testCase.verifyEqual(n, testCase.MemberCount, ...
+                'count did not survive the JSON round trip');
+            testCase.verifyEqual(nPresent, testCase.MemberCount, ...
+                'n_present did not survive the JSON round trip');
+        end
+
+        function testStoredFormSurvivesTheJsonRoundTrip(testCase)
+            % The form that is actually shipped. The database stores the
+            % stripped properties, and stripping is supposed to empty
+            % ingest_locations and nothing else -- did.document's own
+            % TestDocumentFileSeries/testAccessorIsEmptyOnAStoredDocument
+            % asserts a stored document "still knows the series and its size".
+            %
+            % If this one fails while the test above passes, the culprit is
+            % the empty ingest_locations struct array: jsonencode renders an
+            % empty struct array as [], and what comes back may no longer be
+            % shaped like series_info.
+            doc = testCase.makeSeriesDocument();
+            stored = did.document.stripSeriesIngestLocations(doc.document_properties);
+            rebuilt = testCase.jsonRoundTrip(stored);
+
+            testCase.onFailure(@() disp(rebuilt.document_properties.files));
+            testCase.verifyTrue(rebuilt.isFileSeries('chunkdata.bin'), ...
+                'the series declaration did not survive strip + encode/decode');
+            [n, nPresent] = rebuilt.seriesCount('chunkdata.bin');
+            testCase.verifyEqual(n, testCase.MemberCount, ...
+                'count did not survive strip + JSON round trip -- this is NDI-matlab#945, client side');
+            testCase.verifyEqual(nPresent, testCase.MemberCount, ...
+                'n_present did not survive strip + JSON round trip -- this is NDI-matlab#945, client side');
+        end
+
+        function testStrippingAloneKeepsTheCount(testCase)
+            % Isolates stripping from the JSON, so a failure here says the
+            % problem is stripSeriesIngestLocations rather than the encoding.
+            doc = testCase.makeSeriesDocument();
+            stored = ndi.document( ...
+                did.document.stripSeriesIngestLocations(doc.document_properties));
+            [n, nPresent] = stored.seriesCount('chunkdata.bin');
+            testCase.verifyEqual(n, testCase.MemberCount);
+            testCase.verifyEqual(nPresent, testCase.MemberCount);
+        end
+
+    end
+end

--- a/tests/+ndi/+unittest/+database/TestUpdateFileInfoPreservesSeries.m
+++ b/tests/+ndi/+unittest/+database/TestUpdateFileInfoPreservesSeries.m
@@ -1,0 +1,154 @@
+classdef TestUpdateFileInfoPreservesSeries < matlab.unittest.TestCase
+    % ndi.cloud.sync.internal.updateFileInfoForLocalFiles must not destroy
+    % files.series_info.
+    %
+    % This is NDI-matlab#945, and it is ours, not the server's. The function
+    % runs on every downloaded document when SyncFiles is true, to repoint
+    % file locations at the freshly downloaded copies:
+    %
+    %     originalFileInfo = document.document_properties.files.file_info;
+    %     document = document.reset_file_info();
+    %     for i = 1:numel(originalFileInfo)
+    %         ... document = document.add_file(filename, file_location);
+    %     end
+    %
+    % did.document/reset_file_info clears file_info AND series_info -- it says
+    % so in its own comment, "A series' per-instance record is reset with the
+    % rest". The loop then repopulates file_info only. series_info is left as
+    % the empty struct the reset installed, so a downloaded document reports
+    % zero members for a populated series.
+    %
+    % It is silent: isFileSeries still returns true, because that reads
+    % files.file_series, the class declaration from the schema, which the
+    % reset deliberately leaves alone. Only seriesCount notices, and it
+    % returns 0 rather than erroring.
+    %
+    % No credentials and no network: this calls the function directly with a
+    % local directory standing in for the download folder.
+
+    properties (Constant)
+        MemberCount = 4;
+    end
+
+    properties
+        MemberPaths (1,:) cell = {}
+        FileDir
+    end
+
+    methods (TestMethodSetup)
+        function setupDocumentAndFiles(testCase)
+            testCase.applyFixture(matlab.unittest.fixtures.WorkingFolderFixture);
+
+            memberDir = fullfile(pwd, 'level0');
+            mkdir(memberDir);
+            testCase.MemberPaths = cell(1, testCase.MemberCount);
+            for i = 1:testCase.MemberCount
+                p = fullfile(memberDir, sprintf('chunk_%04d.bin', i));
+                fid = fopen(p, 'w');
+                fwrite(fid, uint8(mod((1:16) * i, 251)), 'uint8');
+                fclose(fid);
+                testCase.MemberPaths{i} = p;
+            end
+
+            % Stands in for the folder downloadNdiDocuments passes as
+            % filesTargetFolder.
+            testCase.FileDir = fullfile(pwd, 'downloaded');
+            mkdir(testCase.FileDir);
+        end
+    end
+
+    methods (Access = private)
+        function doc = makeSeriesDocumentWithAFile(testCase)
+            % A document carrying both an ordinary file and a series, because
+            % the function under test walks file_info and the bug is that it
+            % ignores everything else under files.
+            manifestPath = fullfile(pwd, 'chunkdata.bin');
+            fid = fopen(manifestPath, 'w'); fwrite(fid, uint8(1:8)); fclose(fid);
+
+            doc = ndi.document('demoNDISeries', ...
+                'base.name', 'series_reset_doc', ...
+                'demoNDISeries.value', 1, ...
+                'base.session_id', did.ido.unique_id());
+            doc = doc.addFileSeries('chunkdata.bin', testCase.MemberPaths);
+        end
+
+        function placeDownloadedCopies(testCase, doc)
+            % updateFileInfoForLocalFiles only restores entries whose uid it
+            % finds on disk, so put a file at fileDirectory/<uid> for each.
+            fi = doc.document_properties.files.file_info;
+            for i = 1:numel(fi)
+                uid = fi(i).locations(1).uid;
+                p = fullfile(testCase.FileDir, uid);
+                fid = fopen(p, 'w'); fwrite(fid, uint8(1:8)); fclose(fid);
+            end
+        end
+    end
+
+    methods (Test)
+
+        function testSeriesCountIsIntactBeforeTheUpdate(testCase)
+            % Control. If this fails the rest says nothing.
+            doc = testCase.makeSeriesDocumentWithAFile();
+            [n, nPresent] = doc.seriesCount('chunkdata.bin');
+            testCase.verifyEqual(n, testCase.MemberCount);
+            testCase.verifyEqual(nPresent, testCase.MemberCount);
+        end
+
+        function testUpdateFileInfoForLocalFilesKeepsTheSeriesRecord(testCase)
+            % THE BUG. Currently fails: series_info comes back empty.
+            doc = testCase.makeSeriesDocumentWithAFile();
+            testCase.placeDownloadedCopies(doc);
+
+            updated = ndi.cloud.sync.internal.updateFileInfoForLocalFiles( ...
+                doc, testCase.FileDir);
+
+            testCase.onFailure(@() disp(updated.document_properties.files));
+
+            hasSeriesInfo = isfield(updated.document_properties.files, 'series_info') && ...
+                ~isempty(updated.document_properties.files.series_info);
+            testCase.verifyTrue(hasSeriesInfo, ...
+                ['files.series_info was emptied. reset_file_info clears it ' ...
+                 'along with file_info, and the repopulation loop only ' ...
+                 'restores file_info. See NDI-matlab#945.']);
+
+            [n, nPresent] = updated.seriesCount('chunkdata.bin');
+            testCase.verifyEqual(n, testCase.MemberCount, ...
+                'series member count did not survive updateFileInfoForLocalFiles');
+            testCase.verifyEqual(nPresent, testCase.MemberCount, ...
+                'series present-count did not survive updateFileInfoForLocalFiles');
+        end
+
+        function testTheDeclarationSurvivesWhichIsWhyTheLossIsSilent(testCase)
+            % isFileSeries reads files.file_series, the class declaration,
+            % which reset_file_info deliberately leaves alone. So a caller
+            % gets "yes this is a series" and "it has 0 members" together,
+            % with no error anywhere. Pinning this explains the failure mode
+            % to whoever reads it next.
+            doc = testCase.makeSeriesDocumentWithAFile();
+            testCase.placeDownloadedCopies(doc);
+
+            updated = ndi.cloud.sync.internal.updateFileInfoForLocalFiles( ...
+                doc, testCase.FileDir);
+
+            testCase.verifyTrue(updated.isFileSeries('chunkdata.bin'), ...
+                'the class declaration should survive; it comes from the schema');
+        end
+
+        function testFileInfoIsRepointedAtTheDownloadFolder(testCase)
+            % What the function is FOR, and the thing I misread as evidence
+            % that the server preserved file_info: after this call, locations
+            % point into the download folder, not at the original paths.
+            doc = testCase.makeSeriesDocumentWithAFile();
+            testCase.placeDownloadedCopies(doc);
+
+            updated = ndi.cloud.sync.internal.updateFileInfoForLocalFiles( ...
+                doc, testCase.FileDir);
+
+            fi = updated.document_properties.files.file_info;
+            testCase.assertNotEmpty(fi, 'file_info should have been repopulated');
+            testCase.verifyTrue(startsWith(fi(1).locations(1).location, testCase.FileDir), ...
+                'file_info should now point into the download folder');
+        end
+
+    end
+end


### PR DESCRIPTION
This started as a test-only PR. The test found a real bug on its first run, so it now carries the fix too.

## The bug (#945)

`ndi.cloud.sync.internal.updateFileInfoForLocalFiles` runs on every downloaded document when `SyncFiles` is true, to repoint file locations at the freshly downloaded copies:

```matlab
originalFileInfo = document.document_properties.files.file_info;
document = document.reset_file_info();          % clears file_info AND series_info
for i = 1:numel(originalFileInfo)
    ... document = document.add_file(filename, file_location);   % restores file_info ONLY
end
```

`did.document/reset_file_info` clears `files.series_info` along with `files.file_info` — its own comment says *"A series' per-instance record is reset with the rest"*. The loop repopulates `file_info` only. This function predates file series.

So a downloaded document reported **zero members for a populated series**, and did it silently: `isFileSeries` reads `files.file_series`, the class declaration from the schema, which the reset deliberately leaves alone. A caller sizing an upload or reporting progress on a downloaded 28,000-member series was told "yes, this is a series" and "it has 0 members", with no error anywhere.

Only the `SyncFiles = true` branch is affected (`downloadNdiDocuments` line 125). `updateFileInfoForRemoteFiles` (line 131) mutates `file_info` in place and never resets, so it was never affected.

## The fix

Capture `series_info` before the reset, restore it after the loop with `setproperties`, matching how the remote-side twin writes `files.file_info` back. Carried verbatim: the record holds `name`, `count`, `n_present` and `source_root`; its `ingest_locations` were already emptied on the way into storage, and nothing on this path re-ingests members, so there is nothing to recompute.

## How it was found, and a diagnosis I got wrong

`testManifestSurvivesADownloadFromTheCloud` is new here. The three tests that already existed in `FileSeriesRoundTripTest` upload the dataset and then assert against `testCase.LocalDataset`, which is never re-downloaded — so they established that the cloud *accepts* a document carrying a series manifest, and nothing more. A server that dropped, renamed or altered the manifest would have passed all three. This one downloads the dataset into a fresh folder and reads the series back out.

It failed immediately, and **I diagnosed it as a server bug and was wrong**. The full retraction is on #945. The short version: the downloaded `file_info` I cited as having "survived intact" had `"location": "/tmp/download/files/…"` — a local download path. It had not survived; it had been rebuilt by the very loop that was clearing `series_info`. I built an argument on the contrast between a rewritten field and a cleared one without noticing either was which. Credit to the ndi-cloud-node reviewer who said the server could not be doing this.

## What is here

**Fix**
- `updateFileInfoForLocalFiles` preserves `series_info` across the reset

**Tests**
- `TestUpdateFileInfoPreservesSeries` (4) — calls the function directly with a local directory standing in for the download folder. No credentials, no network. The regression test for this fix, and it also pins *why* the loss is silent, and pins the repointing behaviour I misread.
- `TestDocumentSeriesJsonRoundTrip` (5) — the no-network JSON encode/decode round trip, including the batch cell-array encoding `zip_documents_for_upload` actually performs. Written to split client-from-server; it exonerated the client, which in hindsight should have pointed me back at post-download mutation sooner.
- `testManifestSurvivesADownloadFromTheCloud` — the cloud round trip that found the bug. Now passes.
- `FileSeriesRoundTripTest` now carries the narrative + `ndi.unittest.cloud.APIMessage` pattern used by every other suite in `tests/+ndi/+unittest/+cloud`. It was the outlier. The failure that produced the final diagnosis was legible only because of this — it prints whether `files.series_info` is present and dumps the whole `files` struct.

## Verification

All 12 checks green at `045c0ee`:

| check | result |
|---|---|
| Run tests (No Cloud) | **1,210 tests / 192 suites / 1,177 passed / 33 skipped / 0 failed** |
| Run symmetry tests | pass |
| Cloud CI 1, 2, 3 | pass — Cloud CI 1 is the one that was red |
| Code Analyzer | pass |
| codecov/patch, codecov/project | pass |

Codecov: Lines +5, **Hits +14, Misses −9**. The fix is five lines and turned nine previously-unexercised lines into covered ones — `updateFileInfoForLocalFiles` had no direct test before this, which is a fair part of how it survived.

Also confirmed by @stevevanhooser locally against the **dev** API, where the bug reproduced identically before the fix.

## Still skipped, correctly

`testMembersSurviveTheRoundTrip` remains Incomplete. Its gate is local — `database_existbinarydoc(doc.id(), 'chunkdata.bin_1')` — and members are never ingested: `addFileSeries` records where they are, nothing copies them into `FileDir/<uid>`, and nothing resolves `chunkdata.bin_1` to a uid on read. That is VH-Lab/DID-matlab#173, now being worked separately. When it lands, this test flips to passing with no edit.

## Related

- #945 — the bug, retitled and retracted from its server-side framing
- #946 — the same `reset_file_info` pattern in `ndi.database.fun.extract_docs_files`, which returns documents that `ndi.dataset` stores. Separate PR.
- VH-Lab/DID-matlab#173 — member ingestion and manifest-based read resolution

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0186NbFn61EbbPTYZgVhdAoE

---
_Generated by [Claude Code](https://claude.ai/code/session_0186NbFn61EbbPTYZgVhdAoE)_