### PR TITLE
Fix #946: extract_docs_files drops files.series_info into the dataset it writes

### DIFF
--- a/src/ndi/+ndi/+database/+fun/extract_docs_files.m
+++ b/src/ndi/+ndi/+database/+fun/extract_docs_files.m
@@ -11,6 +11,15 @@ function [docs,target_path] = extract_doc_files(ndi_session_obj, target_path)
     % ndi.common.PathConstants.TempFolder is used and the path is returned as
     % an output.
     %
+    % FILE SERIES. A series' manifest is an ordinary document file and is
+    % copied like one, and the series record (name, count, n_present,
+    % source_root) travels with it. The series MEMBERS are not copied:
+    % current_file_list returns the manifest name only, and member ingestion is
+    % not implemented yet (VH-Lab/DID-matlab#173), so there are no member files
+    % in the source session's store to copy. An extracted document therefore
+    % describes a series whose members are not in TARGET_PATH. Copying them
+    % belongs here once ingestion records them.
+    %
 
     if nargin<2
         target_path = ndi.file.temp_name();
@@ -26,9 +35,47 @@ function [docs,target_path] = extract_doc_files(ndi_session_obj, target_path)
     docs = d;
 
     for i = 1:numel(d)
-        if isfield(d{i}.document_properties,'files')
+        % has_files() rather than isfield(...,'files'): the latter is true for
+        % a document that declares files but has added none, and the loop
+        % below has nothing to do for one. It would still call
+        % reset_file_info, which for such a document is pure destruction.
+        if docs{i}.has_files()
             file_info = did.datastructures.emptystruct('file_name','fullpathfilename');
             fl = docs{i}.current_file_list();
+
+            % reset_file_info clears files.series_info along with file_info --
+            % see did.document/reset_file_info, "A series' per-instance record
+            % is reset with the rest". The loop below restores file_info only,
+            % so without this the extracted copy loses the per-series record
+            % and reports zero members for a populated series. Silently:
+            % isFileSeries reads files.file_series, the class declaration,
+            % which the reset leaves alone, so only seriesCount notices and it
+            % returns 0 rather than erroring. See VH-Lab/NDI-matlab#946.
+            %
+            % Carried across: name, count, n_present and source_root. The
+            % counts describe the SERIES, not where its bytes are, and the
+            % manifest that lists the members is copied verbatim below, so
+            % dropping them would leave seriesCount contradicting the manifest
+            % sitting next to it. source_root is the root those manifest
+            % entries are relative to, so it travels with them.
+            %
+            % NOT carried across: ingest_locations, which name where the
+            % members sit in the SOURCE session and mean nothing in the target
+            % path. Emptied with did.document.stripSeriesIngestLocations, the
+            % same call the database makes on the way into storage -- which is
+            % why this is a no-op for every document database_search returns
+            % today. It is here because an extract's output gets stored
+            % somewhere else (see ndi.dataset.copySessionToDataset), and a copy
+            % destined for another store should carry no path into the source.
+            seriesInfo = [];
+            hasSeriesInfo = isfield(docs{i}.document_properties.files,'series_info') && ...
+                ~isempty(docs{i}.document_properties.files.series_info);
+            if hasSeriesInfo
+                strippedProperties = did.document.stripSeriesIngestLocations( ...
+                    docs{i}.document_properties);
+                seriesInfo = strippedProperties.files.series_info;
+            end
+
             docs{i} = docs{i}.reset_file_info;
             for f = 1:numel(fl)
                 file_info_here = [];
@@ -51,6 +98,10 @@ function [docs,target_path] = extract_doc_files(ndi_session_obj, target_path)
 
                 file_info(end+1) = file_info_here;
                 docs{i} = docs{i}.add_file(file_info_here.file_name,file_info_here.fullpathfilename);
+            end
+
+            if hasSeriesInfo
+                docs{i} = docs{i}.setproperties('files.series_info',seriesInfo);
             end
         end
     end

--- a/tests/+ndi/+unittest/+database/TestExtractDocsFilesPreservesSeries.m
+++ b/tests/+ndi/+unittest/+database/TestExtractDocsFilesPreservesSeries.m
@@ -1,0 +1,232 @@
+classdef TestExtractDocsFilesPreservesSeries < matlab.unittest.TestCase
+    % ndi.database.fun.extract_docs_files must not destroy files.series_info.
+    %
+    % This is NDI-matlab#946, the same shape of bug as #945 on a different
+    % path. The extract loop copies a document's files to a target directory
+    % and repoints the copy at them:
+    %
+    %     fl = docs{i}.current_file_list();
+    %     docs{i} = docs{i}.reset_file_info;
+    %     for f = 1:numel(fl)
+    %         ... docs{i} = docs{i}.add_file(name, fullpathfilename);
+    %     end
+    %
+    % did.document/reset_file_info clears file_info AND series_info -- its own
+    % comment says "A series' per-instance record is reset with the rest". The
+    % loop then repopulates file_info only, so series_info is left as the empty
+    % struct the reset installed and the copy reports zero members for a
+    % populated series.
+    %
+    % WHY THIS ONE IS WORSE THAN #945. docs is a return value, and
+    % ndi.dataset.copySessionToDataset stores it: adding a session to a dataset
+    % runs the extract and then database_adds the result. So where #945
+    % corrupted a document in memory after download, this writes the stripped
+    % document into a dataset as the stored copy. The dataset test below is
+    % what confirms that, rather than reasoning about it from the code path.
+    %
+    % It is silent: isFileSeries reads files.file_series, the class declaration
+    % from the schema, which the reset deliberately leaves alone. So a caller
+    % gets "yes, this is a series" and "it has 0 members" together, with no
+    % error. Only seriesCount notices, and it returns 0 rather than throwing.
+    %
+    % No credentials and no network: a session in a temporary directory, and
+    % the function called directly.
+
+    properties (Constant)
+        MemberCount = 4;
+        SeriesDocName = 'series_extract_doc';
+        SeriesName = 'chunkdata.bin';
+    end
+
+    properties
+        Session
+        TargetPath
+        MemberPaths (1,:) cell = {}
+    end
+
+    methods (TestMethodSetup)
+        function setupSessionWithASeries(testCase)
+            % A session holding one demoNDISeries document with a populated
+            % series. Built the way ndi.unittest.session.buildSession does:
+            % a directory session with documents added straight to it, no
+            % daq systems, so nothing here depends on example data.
+            sessionPath = tempname;
+            mkdir(sessionPath);
+            testCase.Session = ndi.session.dir('exp_series', sessionPath);
+
+            memberDir = fullfile(sessionPath, 'level0');
+            mkdir(memberDir);
+            testCase.MemberPaths = cell(1, testCase.MemberCount);
+            for i = 1:testCase.MemberCount
+                memberPath = fullfile(memberDir, sprintf('chunk_%04d.bin', i));
+                fid = fopen(memberPath, 'w');
+                fwrite(fid, uint8(mod((1:16) * i, 251)), 'uint8');
+                fclose(fid);
+                testCase.MemberPaths{i} = memberPath;
+            end
+
+            doc = ndi.document('demoNDISeries', ...
+                'base.name', testCase.SeriesDocName, ...
+                'demoNDISeries.value', 1, ...
+                'base.session_id', testCase.Session.id());
+            doc = doc.addFileSeries(testCase.SeriesName, testCase.MemberPaths);
+            testCase.Session.database_add(doc);
+
+            % Where the extract puts its copies. Given explicitly so the test
+            % can clean it up; extract_docs_files would otherwise pick a
+            % folder under the NDI temp directory and leave it there.
+            testCase.TargetPath = tempname;
+            mkdir(testCase.TargetPath);
+        end
+    end
+
+    methods (TestMethodTeardown)
+        function teardownSession(testCase)
+            if ~isempty(testCase.Session)
+                sessionPath = testCase.Session.path();
+                if isfolder(sessionPath)
+                    rmdir(sessionPath, 's');
+                end
+            end
+            if ~isempty(testCase.TargetPath) && isfolder(testCase.TargetPath)
+                rmdir(testCase.TargetPath, 's');
+            end
+        end
+    end
+
+    methods (Access = private)
+        function doc = findSeriesDoc(testCase, docs)
+            % The extract returns every document in the session, so pick out
+            % the one under test by name rather than by position.
+            doc = [];
+            for i = 1:numel(docs)
+                if strcmp(docs{i}.document_properties.base.name, testCase.SeriesDocName)
+                    doc = docs{i};
+                    return;
+                end
+            end
+            testCase.assertNotEmpty(doc, ...
+                ['The extract did not return the series document (' ...
+                 testCase.SeriesDocName ').']);
+        end
+
+        function docs = extractDocs(testCase)
+            [docs, ~] = ndi.database.fun.extract_docs_files( ...
+                testCase.Session, testCase.TargetPath);
+        end
+    end
+
+    methods (Test)
+
+        function testTheStoredSessionDocumentHasItsMembers(testCase)
+            % Control. The count has to survive the session's own database
+            % round trip before the extract can be blamed for losing it; if
+            % this fails the rest says nothing.
+            q = ndi.query('base.name', 'exact_string', testCase.SeriesDocName);
+            docs = testCase.Session.database_search(q);
+            testCase.assertNumElements(docs, 1, ...
+                'expected exactly one series document in the session');
+
+            [n, nPresent] = docs{1}.seriesCount(testCase.SeriesName);
+            testCase.verifyEqual(n, testCase.MemberCount);
+            testCase.verifyEqual(nPresent, testCase.MemberCount);
+        end
+
+        function testExtractKeepsTheSeriesRecord(testCase)
+            % THE BUG. Currently fails: series_info comes back empty.
+            extracted = testCase.findSeriesDoc(testCase.extractDocs());
+
+            testCase.onFailure(@() disp(extracted.document_properties.files));
+
+            hasSeriesInfo = isfield(extracted.document_properties.files, 'series_info') && ...
+                ~isempty(extracted.document_properties.files.series_info);
+            testCase.verifyTrue(hasSeriesInfo, ...
+                ['files.series_info was emptied. reset_file_info clears it ' ...
+                 'along with file_info, and the copy loop only restores ' ...
+                 'file_info. See NDI-matlab#946.']);
+
+            [n, nPresent] = extracted.seriesCount(testCase.SeriesName);
+            testCase.verifyEqual(n, testCase.MemberCount, ...
+                'series member count did not survive extract_docs_files');
+            testCase.verifyEqual(nPresent, testCase.MemberCount, ...
+                'series present-count did not survive extract_docs_files');
+        end
+
+        function testTheDeclarationSurvivesWhichIsWhyTheLossIsSilent(testCase)
+            % isFileSeries reads files.file_series, the class declaration,
+            % which reset_file_info deliberately leaves alone. So a caller
+            % gets "yes this is a series" and "it has 0 members" together,
+            % with no error anywhere. Pinning this explains the failure mode
+            % to whoever reads it next.
+            extracted = testCase.findSeriesDoc(testCase.extractDocs());
+
+            testCase.verifyTrue(extracted.isFileSeries(testCase.SeriesName), ...
+                'the class declaration should survive; it comes from the schema');
+        end
+
+        function testTheManifestIsCopiedAndFileInfoRepointed(testCase)
+            % What the function is FOR. The series' manifest is an ordinary
+            % document file, so it travels like one: copied into the target
+            % directory, with file_info pointing at the copy.
+            extracted = testCase.findSeriesDoc(testCase.extractDocs());
+
+            fileInfo = extracted.document_properties.files.file_info;
+            testCase.assertNotEmpty(fileInfo, 'file_info should have been repopulated');
+            testCase.verifyTrue(any(strcmpi(testCase.SeriesName, {fileInfo.name})), ...
+                'the manifest should still be among the copied files');
+
+            index = find(strcmpi(testCase.SeriesName, {fileInfo.name}), 1);
+            copiedPath = fileInfo(index).locations(1).location;
+            testCase.verifyTrue(startsWith(copiedPath, testCase.TargetPath), ...
+                'file_info should point into the extract target directory');
+            testCase.verifyTrue(isfile(copiedPath), ...
+                'the manifest should have been copied to the target directory');
+        end
+
+        function testTheCopyCarriesNoPathIntoTheSourceSession(testCase)
+            % The decision this fix records: an extract carries the series
+            % RECORD (name, count, n_present, source_root) but not
+            % ingest_locations, which name where the members sit in the
+            % source session and are meaningless in the target.
+            %
+            % Today this also holds upstream -- the database strips
+            % ingest_locations on the way into storage, so the documents the
+            % extract reads never carry any. This pins it as a property of
+            % the extract's output regardless, which is what matters for a
+            % copy that gets stored somewhere else.
+            extracted = testCase.findSeriesDoc(testCase.extractDocs());
+
+            testCase.verifyEmpty(extracted.seriesIngestLocations(testCase.SeriesName), ...
+                'the extracted copy should not carry the source session''s member paths');
+        end
+
+        function testASessionCopiedIntoADatasetKeepsItsMembers(testCase)
+            % Why this bug is worse than #945: the extract's return value is
+            % stored. copySessionToDataset runs the extract and database_adds
+            % the result, so a stripped document becomes the dataset's copy
+            % at rest. This is the end-to-end consequence #946 reasoned about
+            % from the code path but had not confirmed.
+            datasetPath = tempname;
+            mkdir(datasetPath);
+            testCase.addTeardown(@() rmdir(datasetPath, 's'));
+            dataset = ndi.dataset.dir('ds_series', datasetPath);
+
+            % The real entry point, the way ndi.unittest.dataset.buildDataset
+            % uses it: add_ingested_session calls copySessionToDataset, which
+            % is where the extract runs.
+            dataset.add_ingested_session(testCase.Session);
+
+            q = ndi.query('base.name', 'exact_string', testCase.SeriesDocName);
+            docs = dataset.database_search(q);
+            testCase.assertNumElements(docs, 1, ...
+                'expected exactly one series document in the dataset');
+
+            [n, nPresent] = docs{1}.seriesCount(testCase.SeriesName);
+            testCase.verifyEqual(n, testCase.MemberCount, ...
+                'the dataset''s stored copy lost the series member count');
+            testCase.verifyEqual(nPresent, testCase.MemberCount, ...
+                'the dataset''s stored copy lost the series present-count');
+        end
+
+    end
+end


### PR DESCRIPTION
Fixes #946.

`ndi.database.fun.extract_docs_files` copies a session's documents and files to a target directory. It calls `reset_file_info` and repopulates `file_info` from `current_file_list` — but `reset_file_info` clears `files.series_info` too ("A series' per-instance record is reset with the rest"), and nothing restored it. The extracted copy reported zero members for a populated series.

Same shape as #945. What differs is where the damage lands.

## Confirmed: it lands in the dataset, at rest

`docs` is a return value and the caller keeps it — `ndi.dataset.copySessionToDataset` runs the extract and `database_add`s the result. #946 reasoned this from the code path without confirming it; `testASessionCopiedIntoADatasetKeepsItsMembers` goes through the real entry point (`add_ingested_session`) and reads the count back out of the dataset's own database. So the stripped document is what a dataset stores, not just a copy that goes wrong in memory.

Silent for the same reason as #945: `isFileSeries` reads `files.file_series`, the class declaration from the schema, which the reset leaves alone. Only `seriesCount` notices, and it returns 0 rather than erroring.

## What an extract may carry across — where this departs from the #945 fix

**Carried: `name`, `count`, `n_present`, `source_root`.** The counts describe the *series*, not where its bytes are, and the manifest listing the members is copied verbatim into the target — so dropping them would leave `seriesCount` contradicting the manifest sitting next to it. `source_root` is the root the manifest's member names are relative to; those bytes travel unchanged, so the root travels with them or the names are orphaned.

**Not carried: `ingest_locations`**, which name where members sit in the *source* session and mean nothing under the target path. #945 could carry the record verbatim because `ingest_locations` were already emptied on the way into storage. That is true here too — the strip is a no-op for every document `database_search` returns today — but it is not the same argument: this function's output gets stored somewhere else, and a copy destined for another store should carry no path back into the source. Done with `did.document.stripSeriesIngestLocations`, the same call the database makes on the way in, so "emptied" means one thing in both places.

## What this does not fix

`current_file_list` deliberately does not expand series members: the copy loop copies the manifest and nothing else, so the members are not in the target directory. They could not be even if the loop wanted them — member ingestion is not implemented yet (VH-Lab/DID-matlab#173), so there are no member files in the source session's store to copy from.

So should an extract that cannot carry members still carry the count? **Yes.** The alternative is a document whose `series_info` says 0 while its manifest, copied intact into the same directory, lists all N. Zero is a false statement about the series; N is a true one, and silent about where the bytes are — which is `file_info`'s job, and it already says truthfully that only the manifest was copied. The honest fix for the missing members is to **copy them**, and that belongs in this function once DID#173 lands ingestion; it is noted in the function's help text so it is not lost. Preserving the count does not make it unnecessary.

## Guard

Now `has_files()` rather than `isfield(document_properties,'files')`. The latter is true for a document that declares files but has added none, and the loop has nothing to do for one — entering was pure destruction. One shape change follows: such a document's `files.file_info` is no longer normalized from the decoded `[]` to a typed empty struct on the way through. Both encode to `[]` at rest, and the only caller adds the copies to a database rather than adding files to them.

## Tests

`tests/+ndi/+unittest/+database/TestExtractDocsFilesPreservesSeries.m` — six tests, no credentials and no network, in the fast No Cloud workflow. A `demoNDISeries` document with four members in a session in a temporary directory:

- the session's stored document still has its four members (control)
- **the bug**: `series_info` survives `extract_docs_files`
- the class declaration survives, which is why the loss is silent
- the manifest is copied and `file_info` repointed at the target directory
- the extracted copy carries no `ingest_locations`
- a session copied into a dataset keeps its member counts

**Both commits were run, so the red/green transition is demonstrated rather than asserted.** Both commits push together, so CI would only have seen the fixed one; the test-only commit `d87b2b6` was dispatched separately ([run 1476](https://github.com/VH-Lab/NDI-matlab/actions/runs/34043100630)) and came back `1 207 tests, 1 172 pass, 2 fail`, the two being `testExtractKeepsTheSeriesRecord` and `testASessionCopiedIntoADatasetKeepsItsMembers`, both **failed by verification** — the code ran, the counts came back 0. The other four tests in the suite passed there, so they are not what is measuring the bug. With the fix: `1 207 tests, 1 174 pass, 0 fail`.

Not touched: `ndi.cloud.sync.internal.updateFileInfoForLocalFiles`, whose fix for #945 is in flight on #944.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VMPdbVkfEbjfEviv6dspHN