### PR TITLE
Fix main: a dataset copy of a populated file series is refused, not stored

### DIFF
--- a/src/ndi/+ndi/+database/+fun/extract_docs_files.m
+++ b/src/ndi/+ndi/+database/+fun/extract_docs_files.m
@@ -20,6 +20,14 @@ function [docs,target_path] = extract_doc_files(ndi_session_obj, target_path)
     % describes a series whose members are not in TARGET_PATH. Copying them
     % belongs here once ingestion records them.
     %
+    % Consequently, STORING an extracted series document in a database that
+    % has never held it is refused: did.implementations.sqlitedb rejects a
+    % document declaring present members while recording no location for any
+    % (VH-Lab/DID-matlab#185). So ndi.dataset.add_ingested_session errors for
+    % a session carrying a populated series, and will until the members can
+    % travel. That is deliberate -- the alternative is a stored manifest full
+    % of uids whose bytes never arrive.
+    %
 
     if nargin<2
         target_path = ndi.file.temp_name();

--- a/tests/+ndi/+unittest/+database/TestExtractDocsFilesPreservesSeries.m
+++ b/tests/+ndi/+unittest/+database/TestExtractDocsFilesPreservesSeries.m
@@ -17,12 +17,19 @@ classdef TestExtractDocsFilesPreservesSeries < matlab.unittest.TestCase
     % struct the reset installed and the copy reports zero members for a
     % populated series.
     %
-    % WHY THIS ONE IS WORSE THAN #945. docs is a return value, and
+    % WHY THIS ONE WAS WORSE THAN #945. docs is a return value, and
     % ndi.dataset.copySessionToDataset stores it: adding a session to a dataset
     % runs the extract and then database_adds the result. So where #945
-    % corrupted a document in memory after download, this writes the stripped
-    % document into a dataset as the stored copy. The dataset test below is
-    % what confirms that, rather than reasoning about it from the code path.
+    % corrupted a document in memory after download, this wrote the stripped
+    % document into a dataset as the stored copy.
+    %
+    % That is no longer what happens, and the last test here says so.
+    % VH-Lab/DID-matlab#185 made the database refuse a document that declares
+    % present series members while recording no way to locate any of them --
+    % which is what an extract produces, because it copies the manifest and
+    % not the members (DID#173). So the dataset copy of a series-carrying
+    % session now ERRORS rather than storing zeroed counts. Losing the counts
+    % was the bug; the refusal is the current answer to what replaces it.
     %
     % It is silent: isFileSeries reads files.file_series, the class declaration
     % from the schema, which the reset deliberately leaves alone. So a caller
@@ -114,6 +121,17 @@ classdef TestExtractDocsFilesPreservesSeries < matlab.unittest.TestCase
             [docs, ~] = ndi.database.fun.extract_docs_files( ...
                 testCase.Session, testCase.TargetPath);
         end
+
+        function closeDatabasesQuietly(~)
+            % Mirrors the mksqlite('close') that add_ingested_session does at
+            % the end of a successful add. Failing to close is not worth
+            % failing a teardown over, and there may be nothing open.
+            try
+                mksqlite('close');
+            catch
+                % nothing open, or no handle to close
+            end
+        end
     end
 
     methods (Test)
@@ -200,32 +218,52 @@ classdef TestExtractDocsFilesPreservesSeries < matlab.unittest.TestCase
                 'the extracted copy should not carry the source session''s member paths');
         end
 
-        function testASessionCopiedIntoADatasetKeepsItsMembers(testCase)
-            % Why this bug is worse than #945: the extract's return value is
-            % stored. copySessionToDataset runs the extract and database_adds
-            % the result, so a stripped document becomes the dataset's copy
-            % at rest. This is the end-to-end consequence #946 reasoned about
-            % from the code path but had not confirmed.
+        function testCopyingASeriesIntoADatasetIsRefusedUntilMembersCanTravel(testCase)
+            % Copying a session that holds a POPULATED series into a dataset
+            % does not work today, and fails loudly rather than quietly. That
+            % is the whole point of the guard, and it is worth pinning.
+            %
+            % HOW THIS GOT HERE. #946 was about the dataset's stored copy
+            % losing its member counts, and this test originally asserted the
+            % counts came back. They do -- out of the extract, which is what
+            % the tests above check. But the extract copies the MANIFEST and
+            % not the members (see extract_docs_files' own help, and
+            % VH-Lab/DID-matlab#173: nothing ingests members yet, so there are
+            % none in the source store to copy). So what reaches the dataset
+            % is a document saying "4 present members" while recording no way
+            % to find one.
+            %
+            % VH-Lab/DID-matlab#185 made did.implementations.sqlitedb refuse
+            % exactly that, for a document the target database has never held:
+            % storing it "produces a manifest full of uids whose bytes will
+            % never arrive". The refusal is correct and it is upstream's call
+            % to make. It also means ndi.dataset.add_ingested_session now
+            % ERRORS for a session carrying a populated series, where before
+            % NDI-matlab#947 it silently stored one with zeroed counts.
+            %
+            % Losing the counts was the bug. Refusing the copy is the current,
+            % deliberate answer to what replaces it. When member copying lands
+            % (DID#173, then the extract work its help text names), this test
+            % should go back to asserting that the dataset's copy keeps its
+            % four members -- the assertion is in the git history of this file.
             datasetPath = tempname;
             mkdir(datasetPath);
             testCase.addTeardown(@() rmdir(datasetPath, 's'));
+            % Registered after the rmdir so it runs BEFORE it (teardowns are
+            % LIFO). add_ingested_session closes the database itself as its
+            % last act; erroring part way through means that never runs, and
+            % an open handle should not be left for the next test.
+            testCase.addTeardown(@() testCase.closeDatabasesQuietly());
             dataset = ndi.dataset.dir('ds_series', datasetPath);
 
             % The real entry point, the way ndi.unittest.dataset.buildDataset
             % uses it: add_ingested_session calls copySessionToDataset, which
             % is where the extract runs.
-            dataset.add_ingested_session(testCase.Session);
-
-            q = ndi.query('base.name', 'exact_string', testCase.SeriesDocName);
-            docs = dataset.database_search(q);
-            testCase.assertNumElements(docs, 1, ...
-                'expected exactly one series document in the dataset');
-
-            [n, nPresent] = docs{1}.seriesCount(testCase.SeriesName);
-            testCase.verifyEqual(n, testCase.MemberCount, ...
-                'the dataset''s stored copy lost the series member count');
-            testCase.verifyEqual(nPresent, testCase.MemberCount, ...
-                'the dataset''s stored copy lost the series present-count');
+            testCase.verifyError(@() dataset.add_ingested_session(testCase.Session), ...
+                'DID:SQLITEDB:FileSeries:MembersNotLocatable', ...
+                ['Copying a session with a populated file series into a ' ...
+                 'dataset should be refused while the extract cannot carry ' ...
+                 'the members. See VH-Lab/DID-matlab#185 and #173.']);
         end
 
     end


### PR DESCRIPTION
**main is red** ([run 1480](https://github.com/VH-Lab/NDI-matlab/actions/runs/34048044453) at `e200ab2`, the merge of #947). This fixes it. One error, zero failures: `TestExtractDocsFilesPreservesSeries/testASessionCopiedIntoADatasetKeepsItsMembers` threw `DID:SQLITEDB:FileSeries:MembersNotLocatable` out of `did.implementations.sqlitedb/do_add_doc`.

## Why it was green on the PR and red on main

Nothing about the change differed — main's tree at `e200ab2` is #947's tree. DID-matlab is installed from *its* main at CI time, and **VH-Lab/DID-matlab#185 merged at 17:17:54Z, about three minutes before this test ran on main at 17:20:31Z**. #947's own run at 15:31Z had the DID from before it. The guard the test now hits did not exist when #947 was verified.

## The guard, and why it's right

#185 makes `sqlitedb` refuse a document that declares present series members while recording no location for any of them, when the target database has never held that document. Its reasoning, from the code: storing it *"produces a manifest full of uids whose bytes will never arrive"*, and the member loop would do it in silence, since an empty `ingest_locations` is simply zero passes.

That is exactly what an extract produces. `extract_docs_files` copies the series **manifest** and not the members — `current_file_list` returns the manifest name only, and nothing ingests members yet (DID#173), so there are none in the source store to copy. #947 made the extract carry `name`, `count`, `n_present`, `source_root` across the reset, which is what lets the guard see the problem at all; before it, the dataset silently stored a series with zeroed counts, which was #946.

So the two changes together turn silent corruption into a loud refusal.

## The behavior change, which is worth a second opinion

**`ndi.dataset.add_ingested_session` now errors for a session carrying a populated file series.** Before #947 it "worked" and stored zeroed counts. That is a real capability regression, and I have not tried to work around it: the alternative on offer is a dataset whose members can never be resolved, and the refusal is upstream's call. But whether NDI should surface that as a raw DID error, catch it with an NDI-level explanation, or block adding such sessions earlier is a design question for @stevevanhooser rather than something to settle in a red-main fix.

## What this changes

- The dataset test asserts the **refusal** instead of the counts, renamed to say so. Its comment records how it got here and what should happen when member copying lands: it goes back to asserting the dataset copy keeps its four members — that assertion is in this file's git history rather than lost.
- `extract_docs_files`' help text gains the consequence, so whoever hits the error finds the reason beside the code that causes it.
- The failing test now closes the database on teardown. `add_ingested_session` does that itself as its last act; erroring part way through means it never runs.

The extract fix from #947 is untouched and still correct. The other five tests in the suite — including that `series_info` survives the extract, which is #946 — are unchanged. **Nothing is skipped, disabled, or quarantined.**

Expected: **1,207 tests / 191 suites / 1,174 pass / 33 skipped / 0 fail**, restoring the count #947 was verified at.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VMPdbVkfEbjfEviv6dspHN

---
_Generated by [Claude Code](https://claude.ai/code/session_01VMPdbVkfEbjfEviv6dspHN)_