### PR TITLE
Fix #912: pass the blank's stimulus id to vlt's control_stimid

### DIFF
--- a/src/ndi/+ndi/+app/+stimulus/tuning_response.m
+++ b/src/ndi/+ndi/+app/+stimulus/tuning_response.m
@@ -290,7 +290,12 @@ classdef tuning_response < ndi.app
 
                 E.database_rm(rdoc);
 
-                controlstimids = control_doc.document_properties.control_stimulus_ids.control_stimulus_ids(:);
+                % Fix NDI-matlab#912: control_stimulus_ids holds per-presentation
+                % blank-presentation numbers, but vlt's control_stimid wants the
+                % blank's stimulus id. Recover it from the presentation_order at
+                % the stored control positions.
+                cs_ids = control_doc.document_properties.control_stimulus_ids.control_stimulus_ids(:);
+                controlstimids = unique(stim_doc.document_properties.stimulus_presentation.presentation_order(cs_ids(~isnan(cs_ids))));
                 freq_mult = [];
                 for j=1:numel(stim_doc.document_properties.stimulus_presentation.stimuli)
                     eval(['freq_multi_here = ' temporalfreqfunc '(stim_doc.document_properties.stimulus_presentation.stimuli(j).parameters);']);


### PR DESCRIPTION
Fixes #912.

`tuning_response` was passing `control_doc.control_stimulus_ids` — the per-presentation *presentation numbers* of each presentation's blank — into `vlt.neuro.stimulus.stimulus_response_scalar` as `'control_stimid'`, which expects a stimulus *id*. `findcontrolstimulus` then did `ismember(stimid, controlstimid)`, matching presentation numbers against stimulus ids, and with a pseudorandom presentation order it subtracted the wrong stimulus as the blank.

As detailed in the issue, this manifested as a near-constant baseline offset — tuning curve shape, peak direction, and OI/DI were unaffected (the argmax is invariant to a constant shift), but the zero point was wrong, sometimes visibly pushing null directions below zero. `stimulus_response_scalar_parameters` values (`response_real`/`response_imaginary`) were unaffected; only `control_response_*` shifted.

## The change

At `src/ndi/+ndi/+app/+stimulus/tuning_response.m:293`, recover the blank's stimulus id from the presentations the control positions point at:

```matlab
cs_ids = control_doc.document_properties.control_stimulus_ids.control_stimulus_ids(:);
controlstimids = unique(stim_doc.document_properties.stimulus_presentation.presentation_order(cs_ids(~isnan(cs_ids))));
```

`control_stimid` now receives the id it was documented to receive. A set with no control leaves `cs_ids` all NaN, yielding an empty `controlstimids` and preserving the existing "no control" behaviour.

## Not addressed here

- **Whether to recompute existing `stimulus_response_scalar` documents.** Their `response_real`/`response_imaginary` are unaffected; only stored `control_response_*` shifts. Left for a separate decision, per the issue.
- **The fuller fix noted in the issue** — a `control_stimnumber` argument on `vlt.neuro.stimulus.stimulus_response_scalar` that takes the stored per-presentation indexes directly and skips re-derivation. That change lives in `vlt` and has other callers; out of scope for this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012KkYb7QWPgC4WE9N8VFkcM

---
_Generated by [Claude Code](https://claude.ai/code/session_012KkYb7QWPgC4WE9N8VFkcM)_