### PR TITLE
Batch presign in download_file_from_cloud (DID #173 step 3)

### DIFF
--- a/src/ndi/+ndi/+cloud/+download/+internal/batchSignedUrlLookup.m
+++ b/src/ndi/+ndi/+cloud/+download/+internal/batchSignedUrlLookup.m
@@ -1,0 +1,135 @@
+function url = batchSignedUrlLookup(cloudDatasetId, cloudDocumentId, seriesName, uid, options)
+%BATCHSIGNEDURLLOOKUP Look one uid up in the per-document signed-URL cache.
+%
+%   URL = ndi.cloud.download.internal.batchSignedUrlLookup( ...
+%             cloudDatasetId, cloudDocumentId, seriesName, uid)
+%
+%   Returns the pre-signed GET URL for one file uid inside a given
+%   (dataset, document [, series]) scope, or "" when no URL could be
+%   obtained. On a cache miss for the scope, the whole scope is fetched
+%   with ndi.cloud.api.files.getSignedURLSetAll -- one API round trip
+%   for every uid the document (or the named file series) references --
+%   and cached in-process for the returned URLs' lifetime. Subsequent
+%   uids in the same scope resolve from the cache without another
+%   round trip.
+%
+%   Motivation: DID's customFileHandler previously called
+%   ndi.cloud.api.files.getFileDetails once per uid, so opening a
+%   28,000-member lightsheet series cost 28,000 API round trips
+%   (VH-Lab/DID-matlab#173 step 3, tracked here as
+%   VH-Lab/NDI-matlab#952). This helper turns that into one call per
+%   document (or one per series scope) plus the S3 GETs that were
+%   always going to happen.
+%
+%   Empty return values are legitimate answers, not errors: the batch
+%   call may fail (network, auth, timeout) or the map it returns may
+%   not name this uid (data drift). The caller falls back to
+%   getFileDetails in either case. The batch is an optimization, not
+%   an authority.
+%
+%   Inputs:
+%       cloudDatasetId  (1,1) string  - the dataset id
+%       cloudDocumentId (1,1) string  - the document id; when empty,
+%                                       lookup is bypassed and "" is
+%                                       returned (no document context,
+%                                       nothing to batch against).
+%       seriesName      (1,1) string  - "" for a whole-document scope,
+%                                       or a file-series name to scope
+%                                       the batch to that series only
+%                                       (the endpoint accepts this).
+%       uid             (1,1) string  - the file uid to resolve.
+%
+%   Name-Value Pairs:
+%       signer     - Function handle overriding the batch API call.
+%                    Called as [ok, answer] = signer(datasetId,
+%                    documentId, 'fileSeries', seriesName). Defaults to
+%                    @ndi.cloud.api.files.getSignedURLSetAll. Present
+%                    so tests can inject a scripted response without a
+%                    live server.
+%       clearCache - If true, drop the in-process cache before doing
+%                    anything else. Present for test isolation.
+%       ttlSeconds - How long a cached scope stays valid, in seconds.
+%                    Default 20*3600 (the server currently signs URLs
+%                    for 24 h, leaving a buffer). A scope past its
+%                    TTL is refetched on the next miss.
+%
+%   Outputs:
+%       url         - The pre-signed URL for uid (char), or "" (string
+%                     scalar) when no URL is available.
+%
+%   See also: ndi.cloud.api.files.getSignedURLSetAll,
+%             ndi.cloud.api.files.getFileDetails
+    arguments
+        cloudDatasetId  (1,1) string
+        cloudDocumentId (1,1) string
+        seriesName      (1,1) string
+        uid             (1,1) string
+        options.signer     = @ndi.cloud.api.files.getSignedURLSetAll
+        options.clearCache (1,1) logical = false
+        options.ttlSeconds (1,1) double  = 20*3600
+    end
+
+    % The persistent cache. Keyed on 'datasetId/documentId/seriesName'.
+    % Each entry is a struct with `.map` (containers.Map uid -> URL) and
+    % `.fetchedAt` (datetime, UTC).
+    persistent CACHE
+    if isempty(CACHE) || options.clearCache
+        CACHE = containers.Map('KeyType','char','ValueType','any');
+    end
+
+    url = "";
+
+    % No document context -- e.g. a 2-arg handler call, or a caller that
+    % hasn't got one -- means there is nothing to batch against.
+    if strlength(cloudDocumentId) == 0
+        return
+    end
+
+    cacheKey = sprintf('%s/%s/%s', ...
+        char(cloudDatasetId), char(cloudDocumentId), char(seriesName));
+
+    now_utc = datetime('now','TimeZone','UTC');
+
+    entry = [];
+    if isKey(CACHE, cacheKey)
+        e = CACHE(cacheKey);
+        if seconds(now_utc - e.fetchedAt) < options.ttlSeconds
+            entry = e;
+        else
+            % Stale; drop and refetch.
+            remove(CACHE, cacheKey);
+        end
+    end
+
+    if isempty(entry)
+        % Populate the cache for this scope. The signer is expected to
+        % return `answer.files` as a containers.Map from uid to URL --
+        % which is what getSignedURLSetAll produces via signedURLFileMap.
+        try
+            if strlength(seriesName) > 0
+                [ok, answer] = options.signer(cloudDatasetId, cloudDocumentId, ...
+                    'fileSeries', seriesName);
+            else
+                [ok, answer] = options.signer(cloudDatasetId, cloudDocumentId);
+            end
+        catch
+            ok = false;
+            answer = [];
+        end
+        if ~ok || ~isstruct(answer) || ~isfield(answer,'files') || ...
+                ~isa(answer.files,'containers.Map')
+            % Any failure or unexpected shape -> no batch URL. Don't
+            % cache a bad answer; do not raise. The caller falls back
+            % to getFileDetails for this uid.
+            return
+        end
+        entry = struct('map', answer.files, 'fetchedAt', now_utc);
+        CACHE(cacheKey) = entry;
+    end
+
+    key = char(uid);
+    if isKey(entry.map, key)
+        url = entry.map(key);
+        if isstring(url) && isscalar(url), url = char(url); end
+    end
+end

--- a/src/ndi/+ndi/+database/+implementations/+database/didsqlite.m
+++ b/src/ndi/+ndi/+database/+implementations/+database/didsqlite.m
@@ -152,10 +152,10 @@ classdef  didsqlite < ndi.database
     end
 end
 
-function download_file_from_cloud(destPath, sourcePath)
+function download_file_from_cloud(destPath, sourcePath, context)
     % DOWNLOAD_FILE_FROM_CLOUD - retrieve an ndic:// file for DID
     %
-    % DOWNLOAD_FILE_FROM_CLOUD(DESTPATH, SOURCEPATH)
+    % DOWNLOAD_FILE_FROM_CLOUD(DESTPATH, SOURCEPATH, [CONTEXT])
     %
     % Satisfies did.database's customFileHandler contract: retrieve the file
     % identified by SOURCEPATH and leave it at DESTPATH. SOURCEPATH must be an
@@ -163,8 +163,23 @@ function download_file_from_cloud(destPath, sourcePath)
     % fresh here because pre-signed URLs expire, which is why documents store
     % the durable identifier rather than a URL.
     %
+    % CONTEXT is the per-call struct DID's dispatchCustomFileHandler passes
+    % when a handler declares three or more inputs (DID-matlab#186): it
+    % carries the caller's documentId and, for a series member, the
+    % series name. When present those are used to look the uid up in a
+    % per-document signed-URL cache -- one API round trip per DOCUMENT
+    % (or per fileSeries scope) instead of one per uid, closing DID
+    % #173's step 3 for the read path. Falls back to per-uid
+    % getFileDetails when no context is given or the batch call cannot
+    % answer -- so a 2-arg handler-shaped caller, and any uid missing
+    % from the batch response, still work.
+    %
     % Previously a nested function inside do_openbinarydoc. It is file-local so
     % that do_add can pass the same handler.
+
+    if nargin < 3
+        context = struct();
+    end
 
     if startsWith(sourcePath, 'ndic://')
         % Cache-hit short-circuit. The customFileHandler contract is "leave
@@ -182,12 +197,25 @@ function download_file_from_cloud(destPath, sourcePath)
         cloudDatasetId = cloudPath{1};
         ndiFileUid = cloudPath{2};
 
-        [success, answer, ~] = ndi.cloud.api.files.getFileDetails(cloudDatasetId, ndiFileUid);
-        if ~success
-            error(['Failed to get file details: ' answer.message]);
+        % Try the per-document batch cache first. Empty documentId
+        % (2-arg dispatch, or an older DID) makes this a no-op that
+        % returns "".
+        [docId, seriesName] = readContext(context);
+        fileUrl = ndi.cloud.download.internal.batchSignedUrlLookup( ...
+            string(cloudDatasetId), docId, seriesName, string(ndiFileUid));
+
+        if strlength(fileUrl) == 0
+            % No batch URL for this uid -- either no document context,
+            % or the batch call failed, or the returned map did not name
+            % this uid. Fall back to the per-uid mint, which is exactly
+            % what this handler did before #952.
+            [success, answer, ~] = ndi.cloud.api.files.getFileDetails(cloudDatasetId, ndiFileUid);
+            if ~success
+                error(['Failed to get file details: ' answer.message]);
+            end
+            fileUrl = answer.downloadUrl;
         end
-        fileUrl = answer.downloadUrl;
-        [success2, answer2] = ndi.cloud.api.files.getFile(fileUrl, destPath, 'useCurl', true);
+        [success2, answer2] = ndi.cloud.api.files.getFile(char(fileUrl), destPath, 'useCurl', true);
         if ~success2
             error(['Failed to download file from cloud: ' answer2]);
         end
@@ -196,5 +224,21 @@ function download_file_from_cloud(destPath, sourcePath)
             ['The source path "%s" uses an unsupported file location type. ' ...
             'Expected a path starting with "ndic://".'], ...
             sourcePath);
+    end
+end
+
+function [docId, seriesName] = readContext(context)
+    % Pull documentId and seriesName from the DID handler context, if
+    % either field is present. Missing values become "" so the batch
+    % lookup can treat them uniformly.
+    docId = "";
+    seriesName = "";
+    if isstruct(context)
+        if isfield(context,'documentId') && ~isempty(context.documentId)
+            docId = string(context.documentId);
+        end
+        if isfield(context,'seriesName') && ~isempty(context.seriesName)
+            seriesName = string(context.seriesName);
+        end
     end
 end

--- a/tests/+ndi/+unittest/BatchSignedUrlLookupTest.m
+++ b/tests/+ndi/+unittest/BatchSignedUrlLookupTest.m
@@ -1,0 +1,186 @@
+classdef BatchSignedUrlLookupTest < matlab.unittest.TestCase
+% BATCHSIGNEDURLLOOKUPTEST - the per-document signed-URL cache.
+%
+% Tests the helper that turns "one API round trip per uid" into "one per
+% document (or per fileSeries scope)": NDI-matlab#952, closing DID
+% #173's step 3 for the read path. All tests inject a scripted signer
+% (a function handle mimicking getSignedURLSetAll) so nothing hits the
+% network; the batch API's own paging and merging live in
+% SignedURLSetMockTest.
+
+    methods (Access = private)
+        function signer = countingSigner(~, filesMap, counterHandle)
+            % A signer that returns `filesMap` verbatim and bumps
+            % counterHandle('n') on each call. counterHandle is a
+            % containers.Map used as a mutable scalar so mutation is
+            % visible across returned closures.
+            signer = @doSign;
+            function [ok, answer] = doSign(~, ~, varargin)
+                counterHandle('n') = counterHandle('n') + 1;
+                counterHandle('lastArgs') = varargin;
+                ok = true;
+                answer = struct('files', filesMap, ...
+                                'pages', 1, ...
+                                'expiresAt', '2026-12-31T00:00:00Z');
+            end
+        end
+
+        function m = mapOf(~, uidUrlPairs)
+            m = containers.Map('KeyType','char','ValueType','any');
+            for i = 1:size(uidUrlPairs,1)
+                m(uidUrlPairs{i,1}) = uidUrlPairs{i,2};
+            end
+        end
+    end
+
+    methods (Test)
+
+        function testOneCallCoversEveryUidInADocument(testCase)
+            % The whole point. Two uids in the same document; the batch
+            % signer is called ONCE and both uids resolve.
+            counter = containers.Map('KeyType','char','ValueType','any');
+            counter('n') = 0;
+            filesMap = testCase.mapOf({ ...
+                '4192a3c0dd1b4e00_3fe8a1b2c3d4e5f6', 'https://s3/one'; ...
+                '4192a3c0dd1b4e00_4fe8a1b2c3d4e5f6', 'https://s3/two'});
+            signer = testCase.countingSigner(filesMap, counter);
+
+            u1 = ndi.cloud.download.internal.batchSignedUrlLookup( ...
+                "ds", "doc", "", "4192a3c0dd1b4e00_3fe8a1b2c3d4e5f6", ...
+                'signer', signer, 'clearCache', true);
+            u2 = ndi.cloud.download.internal.batchSignedUrlLookup( ...
+                "ds", "doc", "", "4192a3c0dd1b4e00_4fe8a1b2c3d4e5f6", ...
+                'signer', signer);
+
+            testCase.verifyEqual(u1, 'https://s3/one');
+            testCase.verifyEqual(u2, 'https://s3/two');
+            testCase.verifyEqual(counter('n'), 1, ...
+                'Two uids in one document must cost one batch call.');
+        end
+
+        function testSeriesNameIsPassedToTheSigner(testCase)
+            % A series-scoped call must reach the endpoint with
+            % ?fileSeries=<name>, so the server can return only that
+            % series' members. Without this, a 28,000-chunk series
+            % would page through every other file in the document.
+            counter = containers.Map('KeyType','char','ValueType','any');
+            counter('n') = 0;
+            counter('lastArgs') = {};
+            filesMap = testCase.mapOf({'aa_bb', 'https://s3/x'});
+            signer = testCase.countingSigner(filesMap, counter);
+
+            url = ndi.cloud.download.internal.batchSignedUrlLookup( ...
+                "ds", "doc", "chunkdata.bin", "aa_bb", ...
+                'signer', signer, 'clearCache', true);
+
+            testCase.verifyEqual(url, 'https://s3/x');
+            args = counter('lastArgs');
+            testCase.assertGreaterThanOrEqual(numel(args), 2);
+            testCase.verifyEqual(args{1}, 'fileSeries', ...
+                'The fileSeries pair must reach the signer.');
+            testCase.verifyEqual(char(args{2}), 'chunkdata.bin');
+        end
+
+        function testDifferentScopesGetDifferentCacheEntries(testCase)
+            % Two different (dataset, document, series) scopes are
+            % independent cache entries: each pays its own batch call,
+            % neither pollutes the other.
+            counter = containers.Map('KeyType','char','ValueType','any');
+            counter('n') = 0;
+            map1 = testCase.mapOf({'aa_bb', 'https://s3/a'});
+            signer = testCase.countingSigner(map1, counter);
+
+            ndi.cloud.download.internal.batchSignedUrlLookup( ...
+                "ds", "doc1", "", "aa_bb", ...
+                'signer', signer, 'clearCache', true);
+            ndi.cloud.download.internal.batchSignedUrlLookup( ...
+                "ds", "doc2", "", "aa_bb", ...
+                'signer', signer);
+
+            testCase.verifyEqual(counter('n'), 2, ...
+                'Two documents must each pay their own batch call.');
+        end
+
+        function testMissingDocumentIdBypassesTheBatch(testCase)
+            % A 2-arg handler dispatch or a context with no documentId
+            % gives us nothing to key on. The lookup must return "" so
+            % the caller falls back to per-uid getFileDetails.
+            counter = containers.Map('KeyType','char','ValueType','any');
+            counter('n') = 0;
+            signer = testCase.countingSigner(testCase.mapOf({}), counter);
+
+            url = ndi.cloud.download.internal.batchSignedUrlLookup( ...
+                "ds", "", "", "aa_bb", ...
+                'signer', signer, 'clearCache', true);
+
+            testCase.verifyEqual(url, "");
+            testCase.verifyEqual(counter('n'), 0, ...
+                'No documentId => no wasted batch call.');
+        end
+
+        function testUidNotInBatchResponseReturnsEmpty(testCase)
+            % Data drift: the batch call succeeds but names a uid the
+            % caller didn't ask about. The lookup returns "" and lets
+            % the caller fall back rather than making up an answer.
+            counter = containers.Map('KeyType','char','ValueType','any');
+            counter('n') = 0;
+            filesMap = testCase.mapOf({'other_uid', 'https://s3/other'});
+            signer = testCase.countingSigner(filesMap, counter);
+
+            url = ndi.cloud.download.internal.batchSignedUrlLookup( ...
+                "ds", "doc", "", "aa_bb", ...
+                'signer', signer, 'clearCache', true);
+
+            testCase.verifyEqual(url, "");
+        end
+
+        function testFailingSignerReturnsEmpty(testCase)
+            % A signer that reports ok=false leaves the caller in the
+            % same state a totally missing batch endpoint would: "".
+            % Nothing is cached, and the next call retries -- callers
+            % that recover on a subsequent request must be able to.
+            function [ok, answer] = failingSigner(varargin) %#ok<INUSD>
+                ok = false;
+                answer = struct('message','oops');
+            end
+
+            url1 = ndi.cloud.download.internal.batchSignedUrlLookup( ...
+                "ds", "doc", "", "aa_bb", ...
+                'signer', @failingSigner, 'clearCache', true);
+            testCase.verifyEqual(url1, "");
+
+            counter = containers.Map('KeyType','char','ValueType','any');
+            counter('n') = 0;
+            goodSigner = testCase.countingSigner( ...
+                testCase.mapOf({'aa_bb','https://s3/ok'}), counter);
+            url2 = ndi.cloud.download.internal.batchSignedUrlLookup( ...
+                "ds", "doc", "", "aa_bb", ...
+                'signer', goodSigner);
+            testCase.verifyEqual(url2, 'https://s3/ok', ...
+                'A previous failure must not poison the cache.');
+        end
+
+        function testExpiredEntryIsRefetched(testCase)
+            % Once TTL has elapsed a cached scope is dropped and the
+            % next call goes back to the signer, so a MATLAB session
+            % that outlives the pre-signed window still gets fresh URLs.
+            counter = containers.Map('KeyType','char','ValueType','any');
+            counter('n') = 0;
+            signer = testCase.countingSigner( ...
+                testCase.mapOf({'aa_bb','https://s3/x'}), counter);
+
+            ndi.cloud.download.internal.batchSignedUrlLookup( ...
+                "ds", "doc", "", "aa_bb", ...
+                'signer', signer, 'clearCache', true, 'ttlSeconds', 0);
+            % Any non-zero delay makes the ttl=0 entry stale; even in
+            % the same clock second, seconds(...) > 0 for datetime('now').
+            pause(0.01);
+            ndi.cloud.download.internal.batchSignedUrlLookup( ...
+                "ds", "doc", "", "aa_bb", ...
+                'signer', signer, 'ttlSeconds', 0);
+
+            testCase.verifyEqual(counter('n'), 2, ...
+                'An expired scope must refetch on the next miss.');
+        end
+    end
+end


### PR DESCRIPTION
Closes #952. Wires the batch presign endpoint into DID's customFileHandler retrieval path, now that [VH-Lab/DID-matlab#187](https://github.com/VH-Lab/DID-matlab/pull/187) has widened the handler contract with document context.

## The problem

`download_file_from_cloud` called `ndi.cloud.api.files.getFileDetails` once per uid. Opening a 28,000-member lightsheet series cost **28,000** API round trips against the mint endpoint (the S3 GETs on top were always going to happen). This closes step 3 of DID-matlab #173 for the read path.

## The change

**One new helper**, `+ndi/+cloud/+download/+internal/batchSignedUrlLookup`:

- Persistent in-process cache, keyed on `(cloudDatasetId, cloudDocumentId, seriesName?)`.
- On a miss, fetches the whole scope with `ndi.cloud.api.files.getSignedURLSetAll` — one API round trip regardless of how many uids the scope contains.
- TTL defaults to 20 h (server-signed URLs live ~24 h, buffer of 4 h).
- Signer is a name-value pair, defaulting to the real API. Tests inject a scripted signer so nothing hits the network.
- A batch failure, a signer error, or a uid not named by the returned map all resolve to `""`. The caller falls back to `getFileDetails` — the batch is an optimization, not an authority.

**`download_file_from_cloud`** opts into DID's 3-arg contract (defaults `context` to `struct()` so a 2-arg call still works), builds `(documentId, seriesName)` from context, consults the cache, and falls back to `getFileDetails` on empty.

**A single scope call covers every uid in the containing document (or fileSeries).** With DID-matlab #187 landed, opening a series of N members costs one signed-url-set call plus N S3 GETs, not N mint calls plus N S3 GETs.

## What isn't in this PR

The two `+cloud/+download/` helpers keep their per-uid path for now:

- `downloadDatasetFiles` operates at **dataset** scope with no documentId in hand — there's no per-document endpoint it can call. Would need a different endpoint (or a per-doc regroup) to batch, out of scope here.
- `downloadGenericFiles` iterates documents but typically has **one file per doc**, so batching is low-value; not worth the complexity in this PR.

Both can be follow-ups if they become worthwhile; NDI-matlab#952 stays open for that.

The `isfile(destPath)` short-circuit at the top of `download_file_from_cloud` is left alone here — separately tracked as VH-Lab/NDI-matlab#950.

## Tests

New `BatchSignedUrlLookupTest` (7 methods), all against a scripted signer:

- `testOneCallCoversEveryUidInADocument` — two uids, one signer call
- `testSeriesNameIsPassedToTheSigner` — `fileSeries=<name>` reaches the endpoint
- `testDifferentScopesGetDifferentCacheEntries` — cache is per `(ds, doc, series)`
- `testMissingDocumentIdBypassesTheBatch` — no docId → no wasted call, returns ""
- `testUidNotInBatchResponseReturnsEmpty` — data-drift case
- `testFailingSignerReturnsEmpty` — a failed batch does not poison the cache
- `testExpiredEntryIsRefetched` — TTL-driven refetch works

Existing `SignedURLSetMockTest` still covers paging/merging inside `getSignedURLSetAll` itself.

## Files

- `src/ndi/+ndi/+cloud/+download/+internal/batchSignedUrlLookup.m` — new
- `src/ndi/+ndi/+database/+implementations/+database/didsqlite.m` — 3-arg opt-in, cache-then-fallback
- `tests/+ndi/+unittest/BatchSignedUrlLookupTest.m` — new

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01M4U3BMzUKXha3y48kYZaHk

---
_Generated by [Claude Code](https://claude.ai/code/session_01M4U3BMzUKXha3y48kYZaHk)_