### PR TITLE
extract_docs_files: copy the series members, not just the manifest

### DIFF
--- a/src/ndi/+ndi/+database/+fun/extract_docs_files.m
+++ b/src/ndi/+ndi/+database/+fun/extract_docs_files.m
@@ -13,20 +13,19 @@ function [docs,target_path] = extract_doc_files(ndi_session_obj, target_path)
     %
     % FILE SERIES. A series' manifest is an ordinary document file and is
     % copied like one, and the series record (name, count, n_present,
-    % source_root) travels with it. The series MEMBERS are not copied:
-    % current_file_list returns the manifest name only, and member ingestion is
-    % not implemented yet (VH-Lab/DID-matlab#173), so there are no member files
-    % in the source session's store to copy. An extracted document therefore
-    % describes a series whose members are not in TARGET_PATH. Copying them
-    % belongs here once ingestion records them.
+    % source_root) travels with it. The MEMBERS are copied too, which
+    % current_file_list does not cover: it returns the manifest name only, so
+    % the members are enumerated from the series record instead and fetched by
+    % their NAME_<i> names, which resolve through the manifest
+    % (VH-Lab/DID-matlab#173, #183).
     %
-    % Consequently, STORING an extracted series document in a database that
-    % has never held it is refused: did.implementations.sqlitedb rejects a
-    % document declaring present members while recording no location for any
-    % (VH-Lab/DID-matlab#185). So ndi.dataset.add_ingested_session errors for
-    % a session carrying a populated series, and will until the members can
-    % travel. That is deliberate -- the alternative is a stored manifest full
-    % of uids whose bytes never arrive.
+    % Each copied member is recorded in the extracted document's
+    % ingest_locations UNDER ITS ORIGINAL UID. That is what lets the copy be
+    % stored somewhere else: did.implementations.sqlitedb refuses a document
+    % declaring present members while recording no location for any of them
+    % (VH-Lab/DID-matlab#185), and ingestion writes each member to
+    % FileDir/<uid> from this record, so reusing the uid keeps the copied
+    % manifest -- which names members by uid -- correct in the new store.
     %
 
     if nargin<2
@@ -50,6 +49,7 @@ function [docs,target_path] = extract_doc_files(ndi_session_obj, target_path)
         if docs{i}.has_files()
             file_info = did.datastructures.emptystruct('file_name','fullpathfilename');
             fl = docs{i}.current_file_list();
+            doc_id_here = d{i}.document_properties.base.id;
 
             % reset_file_info clears files.series_info along with file_info --
             % see did.document/reset_file_info, "A series' per-instance record
@@ -109,6 +109,53 @@ function [docs,target_path] = extract_doc_files(ndi_session_obj, target_path)
             end
 
             if hasSeriesInfo
+                % Copy the members. current_file_list does not name them --
+                % it returns the manifest only, deliberately, so that a
+                % 28,000-member series does not materialise 28,000 names --
+                % so walk the slots the series record declares and fetch each
+                % by its NAME_<i> name, which resolves through the manifest.
+                % An absent slot is normal: a sparse series is the case the
+                % mechanism exists for.
+                for s = 1:numel(seriesInfo)
+                    memberEntries = did.datastructures.emptystruct('index','uid', ...
+                        'location','location_type','ingest','delete_original','parameters');
+                    seriesName = seriesInfo(s).name;
+                    slotCount = 0;
+                    if isfield(seriesInfo(s),'count') && ~isempty(seriesInfo(s).count)
+                        slotCount = seriesInfo(s).count;
+                    end
+                    for m = 1:slotCount
+                        memberName = sprintf('%s_%d',seriesName,m);
+                        [memberExists,memberPath] = ...
+                            ndi_session_obj.database_existbinarydoc(doc_id_here,memberName);
+                        if ~memberExists || isempty(memberPath)
+                            continue;
+                        end
+                        % Keep the ORIGINAL uid: ingestion writes the member to
+                        % FileDir/<uid> from this record, and the manifest we
+                        % just copied names its members by uid, so a fresh uid
+                        % would leave the copy's manifest pointing at nothing.
+                        [~,memberUid,~] = fileparts(memberPath);
+                        memberDestination = [target_path filesep memberUid];
+                        try
+                            copyfile(memberPath,memberDestination);
+                            files_I_made{end+1} = memberDestination;
+                        catch
+                            for j=1:numel(files_I_made)
+                                delete(files_I_made{j});
+                            end
+                            error(['Extraction failed: ' lasterr]);
+                        end
+                        % delete_original 0: these are our copies in
+                        % TARGET_PATH, and the caller was promised the files
+                        % would be there.
+                        memberEntries(end+1) = struct('index',m,'uid',memberUid, ...
+                            'location',memberDestination,'location_type','file', ...
+                            'ingest',1,'delete_original',0,'parameters','');
+                    end
+                    seriesInfo(s).ingest_locations = memberEntries;
+                end
+
                 docs{i} = docs{i}.setproperties('files.series_info',seriesInfo);
             end
         end

--- a/src/ndi/+ndi/+database/+fun/extract_docs_files.m
+++ b/src/ndi/+ndi/+database/+fun/extract_docs_files.m
@@ -116,6 +116,10 @@ function [docs,target_path] = extract_doc_files(ndi_session_obj, target_path)
                 % by its NAME_<i> name, which resolves through the manifest.
                 % An absent slot is normal: a sparse series is the case the
                 % mechanism exists for.
+                % One cell per series, concatenated into files_I_made once
+                % after the loop rather than per series.
+                seriesMemberFiles = repmat({{}},1,numel(seriesInfo));
+
                 for s = 1:numel(seriesInfo)
                     seriesName = seriesInfo(s).name;
                     slotCount = 0;
@@ -151,13 +155,13 @@ function [docs,target_path] = extract_doc_files(ndi_session_obj, target_path)
                         try
                             copyfile(memberPath,memberDestination);
                         catch copyError
-                            % The members copied for THIS series are not in
-                            % files_I_made yet, so clean them up alongside it.
-                            for j=1:memberCount
-                                delete(memberFiles{j});
-                            end
-                            for j=1:numel(files_I_made)
-                                delete(files_I_made{j});
+                            % Members copied for this series, and for earlier
+                            % series of this document, are not in files_I_made
+                            % yet -- clean them up alongside it.
+                            madeSoFar = [files_I_made seriesMemberFiles{:} ...
+                                memberFiles(1:memberCount)];
+                            for j=1:numel(madeSoFar)
+                                delete(madeSoFar{j});
                             end
                             error(['Extraction failed: ' copyError.message]);
                         end
@@ -176,8 +180,9 @@ function [docs,target_path] = extract_doc_files(ndi_session_obj, target_path)
                     % An absent slot leaves a hole, so trim to what was
                     % actually copied; a sparse series is normal.
                     seriesInfo(s).ingest_locations = memberEntries(1:memberCount);
-                    files_I_made = [files_I_made memberFiles(1:memberCount)];
+                    seriesMemberFiles{s} = memberFiles(1:memberCount);
                 end
+                files_I_made = [files_I_made seriesMemberFiles{:}];
 
                 docs{i} = docs{i}.setproperties('files.series_info',seriesInfo);
             end

--- a/src/ndi/+ndi/+database/+fun/extract_docs_files.m
+++ b/src/ndi/+ndi/+database/+fun/extract_docs_files.m
@@ -117,13 +117,24 @@ function [docs,target_path] = extract_doc_files(ndi_session_obj, target_path)
                 % An absent slot is normal: a sparse series is the case the
                 % mechanism exists for.
                 for s = 1:numel(seriesInfo)
-                    memberEntries = did.datastructures.emptystruct('index','uid', ...
-                        'location','location_type','ingest','delete_original','parameters');
                     seriesName = seriesInfo(s).name;
                     slotCount = 0;
                     if isfield(seriesInfo(s),'count') && ~isempty(seriesInfo(s).count)
                         slotCount = seriesInfo(s).count;
                     end
+
+                    % Preallocated to the slot count and trimmed at the end
+                    % rather than grown per member. A level of a lightsheet
+                    % pyramid is tens of thousands of members, which is the
+                    % case this whole mechanism exists for, so growing either
+                    % of these one element at a time is a reallocation per
+                    % member.
+                    memberEntries = repmat(struct('index',0,'uid','', ...
+                        'location','','location_type','file', ...
+                        'ingest',1,'delete_original',0,'parameters',''),1,slotCount);
+                    memberFiles = cell(1,slotCount);
+                    memberCount = 0;
+
                     for m = 1:slotCount
                         memberName = sprintf('%s_%d',seriesName,m);
                         [memberExists,memberPath] = ...
@@ -139,21 +150,33 @@ function [docs,target_path] = extract_doc_files(ndi_session_obj, target_path)
                         memberDestination = [target_path filesep memberUid];
                         try
                             copyfile(memberPath,memberDestination);
-                            files_I_made{end+1} = memberDestination;
-                        catch
+                        catch copyError
+                            % The members copied for THIS series are not in
+                            % files_I_made yet, so clean them up alongside it.
+                            for j=1:memberCount
+                                delete(memberFiles{j});
+                            end
                             for j=1:numel(files_I_made)
                                 delete(files_I_made{j});
                             end
-                            error(['Extraction failed: ' lasterr]);
+                            error(['Extraction failed: ' copyError.message]);
                         end
+
+                        memberCount = memberCount + 1;
+                        memberFiles{memberCount} = memberDestination;
                         % delete_original 0: these are our copies in
                         % TARGET_PATH, and the caller was promised the files
                         % would be there.
-                        memberEntries(end+1) = struct('index',m,'uid',memberUid, ...
-                            'location',memberDestination,'location_type','file', ...
-                            'ingest',1,'delete_original',0,'parameters','');
+                        memberEntries(memberCount) = struct('index',m, ...
+                            'uid',memberUid,'location',memberDestination, ...
+                            'location_type','file','ingest',1, ...
+                            'delete_original',0,'parameters','');
                     end
-                    seriesInfo(s).ingest_locations = memberEntries;
+
+                    % An absent slot leaves a hole, so trim to what was
+                    % actually copied; a sparse series is normal.
+                    seriesInfo(s).ingest_locations = memberEntries(1:memberCount);
+                    files_I_made = [files_I_made memberFiles(1:memberCount)];
                 end
 
                 docs{i} = docs{i}.setproperties('files.series_info',seriesInfo);

--- a/tests/+ndi/+unittest/+database/TestExtractDocsFilesPreservesSeries.m
+++ b/tests/+ndi/+unittest/+database/TestExtractDocsFilesPreservesSeries.m
@@ -23,13 +23,13 @@ classdef TestExtractDocsFilesPreservesSeries < matlab.unittest.TestCase
     % corrupted a document in memory after download, this wrote the stripped
     % document into a dataset as the stored copy.
     %
-    % That is no longer what happens, and the last test here says so.
-    % VH-Lab/DID-matlab#185 made the database refuse a document that declares
-    % present series members while recording no way to locate any of them --
-    % which is what an extract produces, because it copies the manifest and
-    % not the members (DID#173). So the dataset copy of a series-carrying
-    % session now ERRORS rather than storing zeroed counts. Losing the counts
-    % was the bug; the refusal is the current answer to what replaces it.
+    % The extract now copies the series MEMBERS as well as the manifest, and
+    % records them under their original uids, so the dataset copy carries a
+    % series that can actually be read. That closes the loop: preserving the
+    % counts (this issue) is only honest if the bytes the counts describe
+    % travel with them. VH-Lab/DID-matlab#185 refuses a document that declares
+    % present members while recording no way to locate any of them, which is
+    % exactly what an extract produced before the members were copied.
     %
     % It is silent: isFileSeries reads files.file_series, the class declaration
     % from the schema, which the reset deliberately leaves alone. So a caller
@@ -48,6 +48,7 @@ classdef TestExtractDocsFilesPreservesSeries < matlab.unittest.TestCase
     properties
         Session
         TargetPath
+        SeriesDocId
         MemberPaths (1,:) cell = {}
     end
 
@@ -78,6 +79,7 @@ classdef TestExtractDocsFilesPreservesSeries < matlab.unittest.TestCase
                 'base.session_id', testCase.Session.id());
             doc = doc.addFileSeries(testCase.SeriesName, testCase.MemberPaths);
             testCase.Session.database_add(doc);
+            testCase.SeriesDocId = doc.id();
 
             % Where the extract puts its copies. Given explicitly so the test
             % can clean it up; extract_docs_files would otherwise pick a
@@ -151,7 +153,9 @@ classdef TestExtractDocsFilesPreservesSeries < matlab.unittest.TestCase
         end
 
         function testExtractKeepsTheSeriesRecord(testCase)
-            % THE BUG. Currently fails: series_info comes back empty.
+            % THE BUG this suite was written for (#946): series_info came
+            % back empty, because reset_file_info clears it and the copy loop
+            % restored file_info only.
             extracted = testCase.findSeriesDoc(testCase.extractDocs());
 
             testCase.onFailure(@() disp(extracted.document_properties.files));
@@ -201,69 +205,106 @@ classdef TestExtractDocsFilesPreservesSeries < matlab.unittest.TestCase
                 'the manifest should have been copied to the target directory');
         end
 
-        function testTheCopyCarriesNoPathIntoTheSourceSession(testCase)
-            % The decision this fix records: an extract carries the series
-            % RECORD (name, count, n_present, source_root) but not
-            % ingest_locations, which name where the members sit in the
-            % source session and are meaningless in the target.
-            %
-            % Today this also holds upstream -- the database strips
-            % ingest_locations on the way into storage, so the documents the
-            % extract reads never carry any. This pins it as a property of
-            % the extract's output regardless, which is what matters for a
-            % copy that gets stored somewhere else.
+        function testTheCopiedMembersLiveInTheTargetDirectory(testCase)
+            % The members travel with the manifest. Before this, the extract
+            % copied the manifest only and the copy described members that
+            % were nowhere -- which VH-Lab/DID-matlab#185 refuses to store,
+            % rightly.
             extracted = testCase.findSeriesDoc(testCase.extractDocs());
 
-            testCase.verifyEmpty(extracted.seriesIngestLocations(testCase.SeriesName), ...
-                'the extracted copy should not carry the source session''s member paths');
+            entries = extracted.seriesIngestLocations(testCase.SeriesName);
+            testCase.assertNumElements(entries, testCase.MemberCount, ...
+                'every present member should be recorded for ingestion');
+
+            for i = 1:numel(entries)
+                testCase.verifyTrue(startsWith(entries(i).location, testCase.TargetPath), ...
+                    'a copied member should live in the extract target directory');
+                testCase.verifyTrue(isfile(entries(i).location), ...
+                    'a recorded member should actually have been copied');
+                testCase.verifyEqual(entries(i).ingest, 1, ...
+                    'a copied member has to be marked for ingestion or it will not travel');
+            end
         end
 
-        function testCopyingASeriesIntoADatasetIsRefusedUntilMembersCanTravel(testCase)
-            % Copying a session that holds a POPULATED series into a dataset
-            % does not work today, and fails loudly rather than quietly. That
-            % is the whole point of the guard, and it is worth pinning.
-            %
-            % HOW THIS GOT HERE. #946 was about the dataset's stored copy
-            % losing its member counts, and this test originally asserted the
-            % counts came back. They do -- out of the extract, which is what
-            % the tests above check. But the extract copies the MANIFEST and
-            % not the members (see extract_docs_files' own help, and
-            % VH-Lab/DID-matlab#173: nothing ingests members yet, so there are
-            % none in the source store to copy). So what reaches the dataset
-            % is a document saying "4 present members" while recording no way
-            % to find one.
-            %
-            % VH-Lab/DID-matlab#185 made did.implementations.sqlitedb refuse
-            % exactly that, for a document the target database has never held:
-            % storing it "produces a manifest full of uids whose bytes will
-            % never arrive". The refusal is correct and it is upstream's call
-            % to make. It also means ndi.dataset.add_ingested_session now
-            % ERRORS for a session carrying a populated series, where before
-            % NDI-matlab#947 it silently stored one with zeroed counts.
-            %
-            % Losing the counts was the bug. Refusing the copy is the current,
-            % deliberate answer to what replaces it. When member copying lands
-            % (DID#173, then the extract work its help text names), this test
-            % should go back to asserting that the dataset's copy keeps its
-            % four members -- the assertion is in the git history of this file.
+        function testTheCopiedMembersKeepTheirOriginalUids(testCase)
+            % The manifest is copied byte for byte and names its members by
+            % uid, so ingestion has to write each member back to
+            % FileDir/<same uid>. A fresh uid would leave the copy's manifest
+            % pointing at files that do not exist -- and nothing would say so,
+            % because the manifest is not read during add.
+            sourceUids = cell(1, testCase.MemberCount);
+            for i = 1:testCase.MemberCount
+                memberName = sprintf('%s_%d', testCase.SeriesName, i);
+                [tf, memberPath] = testCase.Session.database_existbinarydoc( ...
+                    testCase.SeriesDocId, memberName);
+                testCase.assertTrue(tf, ...
+                    ['member ' memberName ' should be in the source session']);
+                [~, sourceUids{i}, ~] = fileparts(memberPath);
+            end
+
+            extracted = testCase.findSeriesDoc(testCase.extractDocs());
+            entries = extracted.seriesIngestLocations(testCase.SeriesName);
+            copiedUids = {entries.uid};
+
+            testCase.verifyEqual(sort(copiedUids), sort(sourceUids), ...
+                'the copied members should carry the uids the manifest names');
+        end
+
+        function testASessionCopiedIntoADatasetKeepsItsMembers(testCase)
+            % Why this bug is worse than #945: the extract's return value is
+            % stored. copySessionToDataset runs the extract and database_adds
+            % the result, so a stripped document becomes the dataset's copy
+            % at rest. This is the end-to-end consequence #946 reasoned about
+            % from the code path but had not confirmed.
             datasetPath = tempname;
             mkdir(datasetPath);
             testCase.addTeardown(@() rmdir(datasetPath, 's'));
-            % Registered after the rmdir so it runs BEFORE it (teardowns are
-            % LIFO). add_ingested_session closes the database itself as its
-            % last act; erroring part way through means that never runs, and
-            % an open handle should not be left for the next test.
             testCase.addTeardown(@() testCase.closeDatabasesQuietly());
             dataset = ndi.dataset.dir('ds_series', datasetPath);
 
             % The real entry point, the way ndi.unittest.dataset.buildDataset
             % uses it: add_ingested_session calls copySessionToDataset, which
             % is where the extract runs.
-            testCase.verifyError(@() dataset.add_ingested_session(testCase.Session), ...
-                'DID:SQLITEDB:FileSeries:MembersNotLocatable', ...
-                ['Copying a session with a populated file series into a ' ...
-                 'dataset should be refused while the extract cannot carry ' ...
-                 'the members. See VH-Lab/DID-matlab#185 and #173.']);
+            dataset.add_ingested_session(testCase.Session);
+
+            q = ndi.query('base.name', 'exact_string', testCase.SeriesDocName);
+            docs = dataset.database_search(q);
+            testCase.assertNumElements(docs, 1, ...
+                'expected exactly one series document in the dataset');
+
+            [n, nPresent] = docs{1}.seriesCount(testCase.SeriesName);
+            testCase.verifyEqual(n, testCase.MemberCount, ...
+                'the dataset''s stored copy lost the series member count');
+            testCase.verifyEqual(nPresent, testCase.MemberCount, ...
+                'the dataset''s stored copy lost the series present-count');
+        end
+
+        function testTheDatasetCopyKeepsReadableMembers(testCase)
+            % The counts are only honest if the bytes arrived. Read each
+            % member back out of the dataset and compare it to what went in.
+            datasetPath = tempname;
+            mkdir(datasetPath);
+            testCase.addTeardown(@() rmdir(datasetPath, 's'));
+            testCase.addTeardown(@() testCase.closeDatabasesQuietly());
+            dataset = ndi.dataset.dir('ds_series_read', datasetPath);
+            dataset.add_ingested_session(testCase.Session);
+
+            q = ndi.query('base.name', 'exact_string', testCase.SeriesDocName);
+            docs = dataset.database_search(q);
+            testCase.assertNumElements(docs, 1);
+
+            for i = 1:testCase.MemberCount
+                memberName = sprintf('%s_%d', testCase.SeriesName, i);
+                [tf, memberPath] = dataset.database_existbinarydoc(docs{1}, memberName);
+                testCase.assertTrue(tf, ...
+                    ['member ' memberName ' did not arrive in the dataset']);
+
+                fid = fopen(memberPath, 'r');
+                actual = fread(fid, inf, '*uint8')';
+                fclose(fid);
+                testCase.verifyEqual(actual, uint8(mod((1:16) * i, 251)), ...
+                    ['member ' memberName ' arrived with different bytes']);
+            end
         end
 
     end

--- a/tests/+ndi/+unittest/+database/TestExtractDocsFilesPreservesSeries.m
+++ b/tests/+ndi/+unittest/+database/TestExtractDocsFilesPreservesSeries.m
@@ -42,6 +42,7 @@ classdef TestExtractDocsFilesPreservesSeries < matlab.unittest.TestCase
     properties (Constant)
         MemberCount = 4;
         SeriesDocName = 'series_extract_doc';
+        SparseDocName = 'series_extract_sparse_doc';
         SeriesName = 'chunkdata.bin';
     end
 
@@ -277,6 +278,64 @@ classdef TestExtractDocsFilesPreservesSeries < matlab.unittest.TestCase
                 'the dataset''s stored copy lost the series member count');
             testCase.verifyEqual(nPresent, testCase.MemberCount, ...
                 'the dataset''s stored copy lost the series present-count');
+        end
+
+        function testASparseSeriesCopiesOnlyThePresentMembers(testCase)
+            % A sparse series -- a chunk grid whose empty regions were never
+            % written -- is the case the series mechanism exists for, per
+            % did.document/addFileSeries. The copy walks slots 1..count and
+            % skips the absent ones, so this covers the skip and the trim
+            % after it; a dense series exercises neither.
+            sparseDir = fullfile(testCase.Session.path(), 'sparse');
+            mkdir(sparseDir);
+            presentPaths = cell(1, 2);
+            for i = 1:2
+                p = fullfile(sparseDir, sprintf('sparse_%04d.bin', i));
+                fid = fopen(p, 'w');
+                fwrite(fid, uint8(mod((1:8) * (i + 10), 251)), 'uint8');
+                fclose(fid);
+                presentPaths{i} = p;
+            end
+
+            % Slots 1 and 3 present, slot 2 never written: count 3,
+            % n_present 2.
+            sparseDoc = ndi.document('demoNDISeries', ...
+                'base.name', testCase.SparseDocName, ...
+                'demoNDISeries.value', 2, ...
+                'base.session_id', testCase.Session.id());
+            sparseDoc = sparseDoc.addFileSeries(testCase.SeriesName, ...
+                presentPaths, 'indices', [1 3]);
+            testCase.Session.database_add(sparseDoc);
+
+            docs = testCase.extractDocs();
+            extracted = [];
+            for i = 1:numel(docs)
+                if strcmp(docs{i}.document_properties.base.name, testCase.SparseDocName)
+                    extracted = docs{i};
+                    break;
+                end
+            end
+            testCase.assertNotEmpty(extracted, ...
+                'the extract did not return the sparse series document');
+
+            [n, nPresent] = extracted.seriesCount(testCase.SeriesName);
+            testCase.verifyEqual(n, 3, 'a sparse series keeps its slot count');
+            testCase.verifyEqual(nPresent, 2, 'a sparse series keeps its present-count');
+
+            entries = extracted.seriesIngestLocations(testCase.SeriesName);
+            testCase.assertNumElements(entries, 2, ...
+                ['only the present members should be recorded, and the ' ...
+                 'array trimmed to them rather than left with empty slots']);
+            % The slot number, not a 1..n counter. Ingestion names each
+            % member NAME_<index>, so a resequenced index would write the
+            % third member as the second one in the new store.
+            testCase.verifyEqual(sort([entries.index]), [1 3], ...
+                'a copied member should carry its real slot number');
+
+            for i = 1:numel(entries)
+                testCase.verifyTrue(isfile(entries(i).location), ...
+                    'a recorded sparse member should have been copied');
+            end
         end
 
         function testTheDatasetCopyKeepsReadableMembers(testCase)


### PR DESCRIPTION
Makes `ndi.dataset.add_ingested_session` work again for a session carrying a populated file series, by copying the members the extract was leaving behind. Part of #956 (the local half; the cloud half is untouched).

## What was wrong

An extract copied a series' **manifest** and not its members, so the copy described N members that were nowhere. Two changes made that visible rather than silent:

- #947 stopped the extract from dropping `series_info`, so the copy now says "4 members".
- VH-Lab/DID-matlab#185 began refusing to store a document that declares present members while recording no location for any.

Result: `add_ingested_session` errored with `DID:SQLITEDB:FileSeries:MembersNotLocatable` for any session with a series.

## A correction to #951

I recorded that refusal as *expected behaviour* in #951, reasoning that member ingestion didn't exist yet. **That was already false when I wrote it** — VH-Lab/DID-matlab#183 landed member ingestion and manifest-based resolution earlier the same day, so the members were in the source session's store the whole time and could have been copied. The comment I merged onto main saying otherwise is corrected here, and the test that asserted the refusal goes back to asserting the members survive.

## What the copy does

`current_file_list` deliberately does not name members — it returns the manifest only, so a 28,000-member series doesn't materialise 28,000 names — so members are enumerated from the series record's slot count and fetched by their `NAME_<i>` names, which resolve through the manifest. An absent slot is skipped rather than erroring: a sparse series is the case the mechanism exists for.

**Uids are preserved, and that's the part that matters.** Ingestion writes each member to `FileDir/<uid>` taken from `ingest_locations`, and the manifest — copied byte for byte — names its members by uid. A fresh uid per copy would leave the new store's manifest pointing at files that don't exist, and *nothing would report it*, because `add` never reads the manifest. So each member is recorded under the uid it already had.

Members are recorded with `ingest = 1` (required, or they don't travel) and `delete_original = 0` — they're our copies inside `TARGET_PATH`, and the caller was promised the files would be there.

## Tests

Six to eight. The dataset test returns to asserting the copy keeps its four members. Three new:

- copied members live in the target directory and are marked for ingestion
- copied members keep their original uids
- **each member read back out of the dataset has the bytes that went in** — the one that would catch a uid mismatch, which counts alone cannot

## Not covered

The cloud path. `ndi.cloud.upload.scanForUpload` enumerates only the legacy `NAME#` convention, so new-style members never reach the cloud and `downloadDataset` has nothing to fetch. That's #956, it's why main's Cloud CI is red, and this PR does not address it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VMPdbVkfEbjfEviv6dspHN

---
_Generated by [Claude Code](https://claude.ai/code/session_01VMPdbVkfEbjfEviv6dspHN)_