### PR TITLE
Reconstruct series ingest_locations on cloud download

### DIFF
--- a/src/ndi/+ndi/+cloud/+sync/+internal/downloadNdiDocuments.m
+++ b/src/ndi/+ndi/+cloud/+sync/+internal/downloadNdiDocuments.m
@@ -121,8 +121,11 @@ function downloadedNdiDocuments = downloadNdiDocuments(cloudDatasetId, cloudDocu
                 fprintf('Updating document file info (SyncMode.Local, but no new files to point to).\n');
             end
         end
+        % cloudDatasetId is threaded through so
+        % reconstructSeriesIngestLocations can build the 'ndic://' locations
+        % of the reconstructed series ingest_locations (NDI-matlab#958).
         documentUpdateFcn = @(doc) ...
-            ndi.cloud.sync.internal.updateFileInfoForLocalFiles(doc, filesTargetFolder);
+            ndi.cloud.sync.internal.updateFileInfoForLocalFiles(doc, filesTargetFolder, cloudDatasetId);
     else
         if syncOptions.Verbose
             fprintf('"SyncFiles" option is false. Updating document file info to reflect remote files.\n');

--- a/src/ndi/+ndi/+cloud/+sync/+internal/reconstructSeriesIngestLocations.m
+++ b/src/ndi/+ndi/+cloud/+sync/+internal/reconstructSeriesIngestLocations.m
@@ -1,0 +1,138 @@
+function seriesInfo = reconstructSeriesIngestLocations(seriesInfo, fileInfo, fileDirectory, cloudDatasetId)
+%RECONSTRUCTSERIESINGESTLOCATIONS Rebuild series ingest_locations from a downloaded manifest.
+%
+%   SERIESINFO = ndi.cloud.sync.internal.reconstructSeriesIngestLocations( ...
+%       SERIESINFO, FILEINFO, FILEDIRECTORY, CLOUDDATASETID)
+%
+%   For every series in SERIESINFO that declares `n_present > 0` and
+%   carries no `ingest_locations`, this reads the downloaded manifest file
+%   from FILEDIRECTORY and rebuilds a one-per-present-member
+%   `ingest_locations` struct array. Every reconstructed entry is
+%   `ingest = 0` and `delete_original = 0`: the point of the reconstruction
+%   is to satisfy DID-matlab #185's MembersNotLocatable guard on the
+%   following `add_docs`, not to trigger any member download at add time.
+%
+%   Motivation. `ingest_locations` is transient authoring data that DID
+%   strips before storing a document, so a cloud round trip returns
+%   `n_present` without any way to locate the uids. VH-Lab/DID-matlab#185
+%   added a guard that refuses that shape ("its file series ... declares N
+%   present members but records no location for any of them"), and every
+%   `SyncFiles=true` cloud download hit the guard on the first document
+%   with a series. This helper closes that gap on the download side: the
+%   manifest bytes are on disk (SyncFiles just wrote them), so the uid of
+%   each present slot can be read back and the entries reconstructed.
+%   Tracked in VH-Lab/NDI-matlab#958.
+%
+%   Inputs:
+%       seriesInfo      - The document's `files.series_info` struct array.
+%                         Modified in place: each entry that qualifies for
+%                         reconstruction has its `ingest_locations` field
+%                         set on return.
+%       fileInfo        - The document's `files.file_info` struct array.
+%                         Used to look up the manifest's file uid: a series
+%                         named NAME has an ordinary file_info entry whose
+%                         `name` is NAME, whose `locations(1).uid` is the
+%                         manifest's uid, and whose local copy therefore
+%                         lives at fullfile(fileDirectory, manifestUid).
+%       fileDirectory   - Directory that holds the downloaded files, i.e.
+%                         the same directory the earlier per-file download
+%                         wrote to.
+%       cloudDatasetId  - The cloud dataset id. Reconstructed entries use
+%                         'ndic://<cloudDatasetId>/<memberUid>' as their
+%                         `location`, matching the URI scheme
+%                         `download_file_from_cloud` understands.
+%
+%   Outputs:
+%       seriesInfo      - The updated struct array.
+%
+%   A series whose manifest cannot be located (the file_info entry is
+%   missing, the manifest file is not on disk, or `readSeriesManifest`
+%   errors) is left alone -- the guard will fire on `add_docs`, which is
+%   the right signal to give the caller when the download itself was
+%   incomplete.
+%
+%   Every reconstructed entry carries the six fields
+%       { index, uid, location, location_type, ingest, delete_original }
+%   that the DID authoring path already uses, so the shape matches what
+%   `did.implementations.sqlitedb/do_add_doc`'s member loop expects.
+%
+%   See also:
+%       ndi.cloud.sync.internal.updateFileInfoForLocalFiles,
+%       did.file.readSeriesManifest
+
+    arguments
+        seriesInfo
+        fileInfo
+        fileDirectory   (1,1) string
+        cloudDatasetId  (1,1) string
+    end
+
+    if isempty(seriesInfo), return, end
+
+    for k = 1 : numel(seriesInfo)
+        entry = seriesInfo(k);
+        if ~isfield(entry,'n_present') || isempty(entry.n_present) || entry.n_present <= 0
+            continue
+        end
+        if isfield(entry,'ingest_locations') && ~isempty(entry.ingest_locations)
+            continue
+        end
+
+        manifestUid = lookupManifestUid(fileInfo, entry.name);
+        if isempty(manifestUid), continue, end
+
+        manifestPath = char(fullfile(fileDirectory, manifestUid));
+        if ~isfile(manifestPath), continue, end
+
+        try
+            manifest = did.file.readSeriesManifest(manifestPath);
+        catch
+            % A corrupt or short manifest is not something to fix here.
+            % Leave the guard to raise on add_docs.
+            continue
+        end
+
+        ingestLocations = buildIngestLocations(manifest, cloudDatasetId);
+        if isempty(ingestLocations), continue, end
+
+        seriesInfo(k).ingest_locations = ingestLocations;
+    end
+end
+
+function manifestUid = lookupManifestUid(fileInfo, seriesName)
+% Find the file_info entry whose `name` matches the series' name. Its
+% locations(1).uid is the manifest file's uid.
+    manifestUid = '';
+    seriesName = char(seriesName);
+    for m = 1 : numel(fileInfo)
+        if ~strcmp(char(fileInfo(m).name), seriesName), continue, end
+        if isempty(fileInfo(m).locations), return, end
+        manifestUid = char(fileInfo(m).locations(1).uid);
+        return
+    end
+end
+
+function ingestLocations = buildIngestLocations(manifest, cloudDatasetId)
+% One ingest_locations entry per present slot of the manifest.
+% Order matches DID's authoring shape and its `sprintf('%s_%d', name, index)`
+% naming (index is 1-based, same as manifest.uids{index}).
+    ingestLocations = struct( ...
+        'index', {}, ...
+        'uid', {}, ...
+        'location', {}, ...
+        'location_type', {}, ...
+        'ingest', {}, ...
+        'delete_original', {});
+
+    for slot = 1 : manifest.count
+        memberUid = manifest.uids{slot};
+        if isempty(memberUid), continue, end
+        ingestLocations(end+1) = struct( ...
+            'index',           slot, ...
+            'uid',             memberUid, ...
+            'location',        sprintf('ndic://%s/%s', char(cloudDatasetId), memberUid), ...
+            'location_type',   'ndicloud', ...
+            'ingest',          0, ...
+            'delete_original', 0);  %#ok<AGROW>
+    end
+end

--- a/src/ndi/+ndi/+cloud/+sync/+internal/updateFileInfoForLocalFiles.m
+++ b/src/ndi/+ndi/+cloud/+sync/+internal/updateFileInfoForLocalFiles.m
@@ -1,20 +1,42 @@
-function document = updateFileInfoForLocalFiles(document, fileDirectory)
+function document = updateFileInfoForLocalFiles(document, fileDirectory, cloudDatasetId)
 % updateFileInfoForLocalFiles - Update file info of document for local files
 %
 % Syntax:
 %   document = ndi.cloud.sync.internal.updateFileInfoForLocalFiles(document, fileDirectory)
+%   document = ndi.cloud.sync.internal.updateFileInfoForLocalFiles(document, fileDirectory, cloudDatasetId)
 %       updates the file info of the document to point to a file in the
 %       provided (local) file directory
 %
+%       When CLOUDDATASETID is supplied and the document declares any file
+%       series with n_present > 0, the series' ingest_locations are
+%       reconstructed from the downloaded manifest file (one entry per
+%       present member, ingest=0). This satisfies DID-matlab #185's
+%       MembersNotLocatable guard, which refuses a document whose series
+%       records n_present members but records no way to locate any of
+%       them -- exactly the shape a cloud round trip produces, because
+%       ingest_locations is stripped at store time. See NDI-matlab #958.
+%
 % Input Arguments:
-%   document - The document object that contains file info to be updated
-%   fileDirectory - The directory where local files are stored
+%   document       - The document object that contains file info to be updated
+%   fileDirectory  - The directory where local files are stored
+%   cloudDatasetId - Optional; the cloud dataset id, used to build the
+%                    'ndic://' location strings of the reconstructed
+%                    series ingest_locations. When "" (the default) the
+%                    ingest_locations are not reconstructed, and any
+%                    series with n_present > 0 will hit DID's guard on
+%                    the following add_docs.
 %
 % Output Arguments:
 %   document - The updated document object with new file info
 %
 % See also:
 %   ndi.cloud.sync.internal.updateFileInfoForRemoteFiles
+
+    arguments
+        document
+        fileDirectory (1,1) string
+        cloudDatasetId (1,1) string = ""
+    end
 
     if document.has_files()
         originalFileInfo = document.document_properties.files.file_info;
@@ -53,6 +75,10 @@ function document = updateFileInfoForLocalFiles(document, fileDirectory)
         end
 
         if hasSeriesInfo
+            if strlength(cloudDatasetId) > 0
+                originalSeriesInfo = ndi.cloud.sync.internal.reconstructSeriesIngestLocations( ...
+                    originalSeriesInfo, originalFileInfo, fileDirectory, cloudDatasetId);
+            end
             document = document.setproperties('files.series_info', originalSeriesInfo);
         end
     end

--- a/tests/+ndi/+unittest/ReconstructSeriesIngestLocationsTest.m
+++ b/tests/+ndi/+unittest/ReconstructSeriesIngestLocationsTest.m
@@ -1,0 +1,164 @@
+classdef ReconstructSeriesIngestLocationsTest < matlab.unittest.TestCase
+% RECONSTRUCTSERIESINGESTLOCATIONSTEST - the ingest_locations rebuild step.
+%
+% Verifies that ndi.cloud.sync.internal.reconstructSeriesIngestLocations
+% produces the shape DID-matlab #185's guard is looking for, from the same
+% manifest bytes a cloud SyncFiles=true download writes to disk. Targets
+% NDI-matlab #958. Uses real manifests (did.file.writeSeriesManifest and
+% readSeriesManifest are the round trip), not mocks -- the whole point of
+% the fix is that the manifest and the reconstruction agree on uid layout,
+% and only a real manifest can prove that.
+
+    properties
+        Dir % Per-test working folder (the fixture cleans it up)
+    end
+
+    methods (TestMethodSetup)
+        function setupWorkingFolder(testCase)
+            testCase.applyFixture(matlab.unittest.fixtures.WorkingFolderFixture);
+            testCase.Dir = pwd;
+        end
+    end
+
+    methods (Access = private)
+        function [manifestUid, uids] = writeManifest(testCase, count, presentSlots)
+            % Write a manifest into the per-test folder that declares COUNT
+            % slots and populates PRESENTSLOTS with real did.ido.unique_id
+            % uids. Return the manifest's own uid (since the caller of the
+            % SUT resolves the manifest's local path from its uid), and a
+            % 1-by-count cellstr matching the manifest's uids -- so tests
+            % can compare exactly what was written to what was read back.
+            manifestUid = char(did.ido.unique_id());
+            uids = repmat({''}, 1, count);
+            for i = presentSlots
+                uids{i} = char(did.ido.unique_id());
+            end
+            did.file.writeSeriesManifest(fullfile(testCase.Dir, manifestUid), uids);
+        end
+
+        function fi = fileInfoFor(~, seriesName, manifestUid)
+            % A minimal file_info struct array with one entry naming the
+            % series' manifest.
+            fi = struct( ...
+                'name',      seriesName, ...
+                'locations', struct('uid', manifestUid));
+        end
+
+        function si = seriesInfoFor(~, seriesName, count, nPresent)
+            si = struct( ...
+                'name',      seriesName, ...
+                'count',     count, ...
+                'n_present', nPresent);
+        end
+    end
+
+    methods (Test)
+
+        function testReconstructsOneEntryPerPresentSlot(testCase)
+            % A manifest with slots 1, 3, 5 populated (5 total) becomes
+            % three ingest_locations entries, in order. Absent slots are
+            % NOT reconstructed -- the guard only cares that the "present"
+            % members can be found, and inventing entries for absent slots
+            % would falsely claim locations for uids the manifest never
+            % recorded.
+            [manifestUid, uids] = testCase.writeManifest(5, [1 3 5]);
+
+            fi = testCase.fileInfoFor('chunkdata.bin', manifestUid);
+            si = testCase.seriesInfoFor('chunkdata.bin', 5, 3);
+
+            out = ndi.cloud.sync.internal.reconstructSeriesIngestLocations( ...
+                si, fi, testCase.Dir, "ds-42");
+
+            testCase.assertTrue(isfield(out,'ingest_locations'));
+            il = out(1).ingest_locations;
+            testCase.assertNumElements(il, 3);
+
+            expectedIndices = [1 3 5];
+            expectedUids    = uids([1 3 5]);
+            for i = 1:3
+                testCase.verifyEqual(il(i).index, expectedIndices(i));
+                testCase.verifyEqual(il(i).uid, expectedUids{i});
+                testCase.verifyEqual(il(i).location_type, 'ndicloud');
+                testCase.verifyEqual(il(i).ingest, 0, ...
+                    'reconstruction must never trigger an eager download');
+                testCase.verifyEqual(il(i).delete_original, 0);
+                testCase.verifyEqual(il(i).location, ...
+                    sprintf('ndic://ds-42/%s', expectedUids{i}));
+            end
+        end
+
+        function testLeavesExistingIngestLocationsAlone(testCase)
+            % A series that already carries ingest_locations (a doc built
+            % locally and never round-tripped, say) is not touched. The
+            % reconstruction only fires for the shape the guard rejects.
+            [manifestUid, ~] = testCase.writeManifest(3, [1 2 3]);
+            fi = testCase.fileInfoFor('chunkdata.bin', manifestUid);
+
+            si = testCase.seriesInfoFor('chunkdata.bin', 3, 3);
+            existing = struct('index', 1, 'uid', 'kept', ...
+                'location', 'file:///kept', 'location_type', 'file', ...
+                'ingest', 1, 'delete_original', 0);
+            si.ingest_locations = existing;
+
+            out = ndi.cloud.sync.internal.reconstructSeriesIngestLocations( ...
+                si, fi, testCase.Dir, "ds");
+
+            testCase.assertNumElements(out(1).ingest_locations, 1);
+            testCase.verifyEqual(out(1).ingest_locations(1).uid, 'kept');
+        end
+
+        function testSkipsSeriesWithZeroPresent(testCase)
+            % A series that declares no present members has nothing to
+            % locate and no manifest slots to read. Leave it as-is; the
+            % guard already accepts n_present == 0.
+            si = testCase.seriesInfoFor('chunkdata.bin', 3, 0);
+            fi = testCase.fileInfoFor('chunkdata.bin', char(did.ido.unique_id()));
+
+            out = ndi.cloud.sync.internal.reconstructSeriesIngestLocations( ...
+                si, fi, tempdir(), "ds");
+
+            testCase.verifyFalse(isfield(out,'ingest_locations') && ...
+                ~isempty(out(1).ingest_locations), ...
+                'a zero-present series should not carry reconstructed entries');
+        end
+
+        function testMissingManifestFileLeavesEntryAlone(testCase)
+            % SyncFiles could not write the manifest (the download for
+            % that one uid failed). The reconstruction skips it silently
+            % so DID's guard fires on add_docs -- the honest signal that
+            % the download itself was incomplete.
+            si = testCase.seriesInfoFor('chunkdata.bin', 4, 4);
+            % file_info names a manifest whose file is NOT present on disk.
+            fi = testCase.fileInfoFor('chunkdata.bin', char(did.ido.unique_id()));
+
+            out = ndi.cloud.sync.internal.reconstructSeriesIngestLocations( ...
+                si, fi, tempdir(), "ds");
+
+            testCase.verifyFalse(isfield(out,'ingest_locations') && ...
+                ~isempty(out(1).ingest_locations));
+        end
+
+        function testMultipleSeriesReconstructedIndependently(testCase)
+            % Two series in the same document each get their own manifest
+            % read; neither's reconstruction depends on or affects the
+            % other's.
+            [m1, u1] = testCase.writeManifest(2, [1 2]);
+            [m2, u2] = testCase.writeManifest(3, [2 3]);
+
+            fi(1) = testCase.fileInfoFor('a.bin', m1);
+            fi(2) = testCase.fileInfoFor('b.bin', m2);
+            si(1) = testCase.seriesInfoFor('a.bin', 2, 2);
+            si(2) = testCase.seriesInfoFor('b.bin', 3, 2);
+
+            out = ndi.cloud.sync.internal.reconstructSeriesIngestLocations( ...
+                si, fi, testCase.Dir, "ds");
+
+            testCase.assertNumElements(out(1).ingest_locations, 2);
+            testCase.assertNumElements(out(2).ingest_locations, 2);
+            testCase.verifyEqual({out(1).ingest_locations.uid}, u1([1 2]));
+            testCase.verifyEqual({out(2).ingest_locations.uid}, u2([2 3]));
+            testCase.verifyEqual([out(2).ingest_locations.index], [2 3], ...
+                'the recorded index tracks the manifest slot, not a re-numbering');
+        end
+    end
+end


### PR DESCRIPTION
Closes #958. Fixes the Cloud CI 1 red on `main` (and every branched PR) caused by DID-matlab#185's `MembersNotLocatable` guard interacting with the cloud round trip.

## Why CI is red

DID-matlab#185 added a guard that refuses `add_docs` on a document whose series records `n_present > 0` but records no `ingest_locations`. `ingest_locations` is transient authoring data DID strips at store time, so a document coming back from the cloud has `n_present` and no way to locate any of the uids. The guard fires at the first document with a populated series on every `SyncFiles=true` download — that's the `ndi.unittest.cloud.FileSeriesRoundTripTest/testManifestSurvivesADownloadFromTheCloud` failure on main sha `a09ff384` (job `101553721558`), and the same failure on every open PR since #185 landed.

## What this PR does

The download side already has the information the guard needs: `SyncFiles=true` just wrote every series' manifest bytes to disk, and the manifest is the authoritative record of member uids.

- **New `+ndi/+cloud/+sync/+internal/reconstructSeriesIngestLocations`** — for each series with `n_present > 0` and no `ingest_locations`, resolves the manifest's own file uid via the file_info entry whose `name` matches the series, reads the manifest with `did.file.readSeriesManifest`, and builds one entry per present slot:
  ```
  { index, uid, location: sprintf('ndic://%s/%s', datasetId, uid),
    location_type: 'ndicloud', ingest: 0, delete_original: 0 }
  ```
  `ingest=0` is the important part: it satisfies the guard without triggering any member download at add time. A missing or unreadable manifest is left alone so the guard fires — an honest signal that the download was itself incomplete.

- **`updateFileInfoForLocalFiles`** gains an optional `cloudDatasetId` (defaults `""`, backward compatible) and calls the helper right before restoring `series_info`.

- **`downloadNdiDocuments`** threads `cloudDatasetId` to that closure so the `SyncFiles=true` path always reconstructs.

## Why not fix it in DID

The guard is doing its job for the case it exists to catch. NDI has the information the guard needs — the manifest names the uids, the dataset id is known — and softening the guard in DID would erode a protection whose whole point is to reject silently-lossy stored documents. Reconstructing at the NDI boundary keeps the guard strict.

## Not in this PR

- `updateFileInfoForRemoteFiles` (SyncFiles=false) still lets the guard fire on documents with populated series. That path has no local manifest to reconstruct from and needs a separate fix (either downloading the manifest first, or a different reconstruction strategy). Not blocking anything Cloud CI runs today.

## Tests

Five methods in `tests/+ndi/+unittest/ReconstructSeriesIngestLocationsTest.m`, against real `did.file.writeSeriesManifest` / `readSeriesManifest` round trips (mocking the manifest format would defeat the property that this fix depends on — that the two sides agree on layout):

- `testReconstructsOneEntryPerPresentSlot` — slots [1 3 5] of a 5-slot manifest become 3 entries; each has the right `index`, `uid`, `location`, `location_type`, and `ingest=0`.
- `testLeavesExistingIngestLocationsAlone` — pre-existing entries are not overwritten.
- `testSkipsSeriesWithZeroPresent` — no work needed.
- `testMissingManifestFileLeavesEntryAlone` — the download was incomplete; the guard rightfully fires on `add_docs`.
- `testMultipleSeriesReconstructedIndependently` — two series in one document each get their own manifest read.

## Testing on dev API

You can pull this branch and point at the dev API to run `testManifestSurvivesADownloadFromTheCloud` against a series-carrying dataset. The unit tests above prove the reconstruction shape; the integration test proves it satisfies the guard end-to-end.

## Files

- `src/ndi/+ndi/+cloud/+sync/+internal/reconstructSeriesIngestLocations.m` — new
- `src/ndi/+ndi/+cloud/+sync/+internal/updateFileInfoForLocalFiles.m` — accepts and forwards `cloudDatasetId`
- `src/ndi/+ndi/+cloud/+sync/+internal/downloadNdiDocuments.m` — threads `cloudDatasetId` through
- `tests/+ndi/+unittest/ReconstructSeriesIngestLocationsTest.m` — new

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01M4U3BMzUKXha3y48kYZaHk

---
_Generated by [Claude Code](https://claude.ai/code/session_01M4U3BMzUKXha3y48kYZaHk)_