### PR TITLE
Drop dead isfile(destPath) short-circuit in download_file_from_cloud

### DIFF
--- a/src/ndi/+ndi/+database/+implementations/+database/didsqlite.m
+++ b/src/ndi/+ndi/+database/+implementations/+database/didsqlite.m
@@ -182,17 +182,6 @@ function download_file_from_cloud(destPath, sourcePath, context)
     end
 
     if startsWith(sourcePath, 'ndic://')
-        % Cache-hit short-circuit. The customFileHandler contract is "leave
-        % the file identified by SOURCEPATH at DESTPATH"; a file already
-        % present at DESTPATH already satisfies it. Historically the handler
-        % always re-downloaded, which caused DID's cache manager to fire
-        % "already a file with name <uid> in the cache" and fail
-        % do_open_doc for what should have been a cache hit -- the
-        % handler was clobbering a file DID was about to reuse.
-        if isfile(destPath)
-            return;
-        end
-
         cloudPath = split( extractAfter(sourcePath, 'ndic://'), "/" );
         cloudDatasetId = cloudPath{1};
         ndiFileUid = cloudPath{2};


### PR DESCRIPTION
Fixes #950.

## Summary

The `isfile(destPath)` short-circuit at the top of `download_file_from_cloud` in `src/ndi/+ndi/+database/+implementations/+database/didsqlite.m` is dead code after [VH-Lab/DID-matlab#185](https://github.com/VH-Lab/DID-matlab/pull/185): DID now only invokes the `customFileHandler` on a cache miss and hands it a unique per-fetch temp path (`<uid>.<unique>.part`) that never exists before the call, so the `isfile` test is always false.

Prior to #185 the branch was actively unsafe — a truncated leftover at the fixed scratch path would make `isfile` return true and the handler return "success" without downloading, letting DID move the truncated bytes into the cache. Its accompanying comment described that historical DID behaviour and read as though the short-circuit was load-bearing, when in fact #185 removed both the risk and the need for it.

This PR drops the branch (and its comment) entirely, per the issue's preferred remedy.

## Changes

- `src/ndi/+ndi/+database/+implementations/+database/didsqlite.m`: remove the `if isfile(destPath) return; end` block and its comment inside `download_file_from_cloud`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019yU7jRhSn4tUEUCWMLzgG3

---
_Generated by [Claude Code](https://claude.ai/code/session_019yU7jRhSn4tUEUCWMLzgG3)_