### PR TITLE
Upload file series members, not just the series manifest

### DIFF
--- a/src/ndi/+ndi/+database/+internal/list_binary_files.m
+++ b/src/ndi/+ndi/+database/+internal/list_binary_files.m
@@ -13,6 +13,17 @@ function file_manifest = list_binary_files(ndi_dataset, database_documents, verb
     %       'file_path' - The full (absolute) pathname of the file
     %       'docid' - The document id that the file is associated with
     %       'bytes' - The size of the file in bytes
+    %
+    % FILE SERIES. A new-style series (files.file_series) records its members
+    % in a manifest rather than in file_list, and names them NAME_<i>, so the
+    % file_list walk below never sees them -- it handles only the legacy
+    % NAME# convention, whose members are NAME1, NAME2 and so on. Members are
+    % therefore enumerated separately, from the per-series record, and
+    % resolved by name through the manifest (VH-Lab/DID-matlab#183).
+    %
+    % Without this a series reaches the cloud as its manifest alone: a
+    % document declaring N members, none of whose bytes were ever uploaded.
+    % See VH-Lab/NDI-matlab#956.
 
     arguments
         ndi_dataset (1,1) ndi.dataset
@@ -71,6 +82,47 @@ function file_manifest = list_binary_files(ndi_dataset, database_documents, verb
                         file_manifest(curr_idx).bytes = file_info.bytes;
                     end
                 end
+            end
+
+            % Series members, which file_list does not name.
+            seriesInfo = [];
+            if isfield(database_documents{i}.document_properties.files, 'series_info')
+                seriesInfo = database_documents{i}.document_properties.files.series_info;
+            end
+
+            for s = 1:numel(seriesInfo)
+                slotCount = 0;
+                if isfield(seriesInfo(s), 'count') && ~isempty(seriesInfo(s).count)
+                    slotCount = seriesInfo(s).count;
+                end
+                series_name = seriesInfo(s).name;
+
+                % Preallocated and trimmed rather than grown: a lightsheet
+                % pyramid level is tens of thousands of members, and growing
+                % the manifest one entry at a time is a reallocation each.
+                member_entries = repmat(struct('name', '', 'uid', '', ...
+                    'docid', '', 'bytes', 0, 'file_path', ''), 1, slotCount);
+                member_count = 0;
+
+                for m = 1:slotCount
+                    member_name = sprintf('%s_%d', series_name, m);
+                    [member_exists, member_path] = ...
+                        ndi_dataset.database_existbinarydoc(ndi_document_id, member_name);
+                    % An absent slot is normal: a sparse series is the case
+                    % the mechanism exists for.
+                    if ~member_exists || isempty(member_path)
+                        continue;
+                    end
+                    [~, member_uid, ~] = fileparts(member_path);
+                    member_info = dir(member_path);
+                    member_count = member_count + 1;
+                    member_entries(member_count) = struct( ...
+                        'name', member_name, 'uid', member_uid, ...
+                        'docid', ndi_document_id, 'bytes', member_info.bytes, ...
+                        'file_path', member_path);
+                end
+
+                file_manifest = [file_manifest member_entries(1:member_count)]; %#ok<AGROW>
             end
         end
     end

--- a/tests/+ndi/+unittest/+database/TestListBinaryFilesIncludesSeriesMembers.m
+++ b/tests/+ndi/+unittest/+database/TestListBinaryFilesIncludesSeriesMembers.m
@@ -1,0 +1,200 @@
+classdef TestListBinaryFilesIncludesSeriesMembers < matlab.unittest.TestCase
+    % ndi.database.internal.list_binary_files must enumerate file series
+    % members, not just the series manifest.
+    %
+    % This is the upload half of NDI-matlab#956. list_binary_files builds the
+    % manifest that ndi.cloud.sync.internal.uploadFilesForDatasetDocuments
+    % hands to the uploader, so a file the manifest does not name is a file
+    % that never reaches the cloud.
+    %
+    % It walked files.file_list, expanding a series only under the LEGACY
+    % convention -- a name ending in '#', expanded NAME1, NAME2, ... A
+    % new-style series (files.file_series) records its members in a binary
+    % manifest rather than in file_list and names them NAME_<i>, with an
+    % underscore, so it never matched. A series therefore reached the cloud as
+    % its manifest alone: a document declaring N members, none of whose bytes
+    % had been uploaded. The download then had nothing to fetch, which is what
+    % made ndi.unittest.cloud.FileSeriesRoundTripTest's download test fail.
+    %
+    % These tests need no credentials and no network: list_binary_files takes
+    % a local dataset and reads it, so the upload half can be checked in the
+    % fast workflow rather than only in Cloud CI.
+
+    properties (Constant)
+        MemberCount = 4;
+        SeriesDocName = 'series_upload_doc';
+        SeriesName = 'chunkdata.bin';
+    end
+
+    properties
+        Dataset
+        DatasetPath
+    end
+
+    methods (TestMethodSetup)
+        function setupDataset(testCase)
+            testCase.DatasetPath = tempname;
+            mkdir(testCase.DatasetPath);
+            testCase.Dataset = ndi.dataset.dir('ds_upload_series', testCase.DatasetPath);
+        end
+    end
+
+    methods (TestMethodTeardown)
+        function teardownDataset(testCase)
+            try
+                mksqlite('close');
+            catch
+                % nothing open to close
+            end
+            if ~isempty(testCase.DatasetPath) && isfolder(testCase.DatasetPath)
+                rmdir(testCase.DatasetPath, 's');
+            end
+        end
+    end
+
+    methods (Access = private)
+        function doc = addSeriesDocument(testCase, docName, indices)
+            % Adds a demoNDISeries document whose series has a member at each
+            % of INDICES. Empty INDICES means a dense series of MemberCount.
+            memberDir = fullfile(testCase.DatasetPath, ['members_' docName]);
+            mkdir(memberDir);
+
+            if isempty(indices)
+                indices = 1:testCase.MemberCount;
+            end
+            memberPaths = cell(1, numel(indices));
+            for i = 1:numel(indices)
+                p = fullfile(memberDir, sprintf('chunk_%04d.bin', indices(i)));
+                fid = fopen(p, 'w');
+                % Distinct lengths per slot, so a manifest entry that pointed
+                % at the wrong member would show up as a wrong byte count.
+                fwrite(fid, uint8(1:(8 + indices(i))), 'uint8');
+                fclose(fid);
+                memberPaths{i} = p;
+            end
+
+            doc = ndi.document('demoNDISeries', ...
+                'base.name', docName, ...
+                'demoNDISeries.value', 1, ...
+                'base.session_id', testCase.Dataset.id());
+            doc = doc.addFileSeries(testCase.SeriesName, memberPaths, ...
+                'indices', indices);
+            testCase.Dataset.database_add(doc);
+        end
+
+        function manifest = listFiles(testCase)
+            docs = testCase.Dataset.database_search(ndi.query('', 'isa', 'base'));
+            manifest = ndi.database.internal.list_binary_files( ...
+                testCase.Dataset, docs, false);
+        end
+    end
+
+    methods (Test)
+
+        function testTheSeriesManifestIsListed(testCase)
+            % Control: the series' own manifest file is an ordinary document
+            % file and was always listed. If this fails the rest says nothing.
+            testCase.addSeriesDocument(testCase.SeriesDocName, []);
+            manifest = testCase.listFiles();
+
+            testCase.verifyTrue(any(strcmp({manifest.name}, testCase.SeriesName)), ...
+                'the series manifest file should be in the upload manifest');
+        end
+
+        function testEveryMemberIsListed(testCase)
+            % THE BUG (#956): members were never named, so they never
+            % uploaded.
+            testCase.addSeriesDocument(testCase.SeriesDocName, []);
+            manifest = testCase.listFiles();
+
+            names = {manifest.name};
+            for i = 1:testCase.MemberCount
+                expected = sprintf('%s_%d', testCase.SeriesName, i);
+                testCase.verifyTrue(any(strcmp(names, expected)), ...
+                    ['member ' expected ' is missing from the upload ' ...
+                     'manifest, so its bytes would never reach the cloud']);
+            end
+        end
+
+        function testEachMemberCarriesItsOwnUidAndSize(testCase)
+            % A member is uploaded by uid and located by file_path, so an
+            % entry that named the right member with another member's uid
+            % would upload the wrong bytes under the right name.
+            testCase.addSeriesDocument(testCase.SeriesDocName, []);
+            manifest = testCase.listFiles();
+
+            for i = 1:testCase.MemberCount
+                entry = testCase.entryNamed(manifest, ...
+                    sprintf('%s_%d', testCase.SeriesName, i));
+                testCase.verifyNotEmpty(entry.uid, 'a member needs its uid to be uploaded');
+                testCase.verifyTrue(isfile(entry.file_path), ...
+                    'a member''s file_path should resolve to a real file');
+                % Slot i was written with 8+i bytes.
+                testCase.verifyEqual(entry.bytes, 8 + i, ...
+                    'the manifest entry has the wrong member''s size');
+            end
+
+            memberUids = cell(1, testCase.MemberCount);
+            for i = 1:testCase.MemberCount
+                uidEntry = testCase.entryNamed(manifest, ...
+                    sprintf('%s_%d', testCase.SeriesName, i));
+                memberUids{i} = uidEntry.uid;
+            end
+            testCase.verifyNumElements(unique(memberUids), testCase.MemberCount, ...
+                'each member must have a distinct uid');
+        end
+
+        function testASparseSeriesListsOnlyItsPresentMembers(testCase)
+            % Slots 1 and 3 written, slot 2 never was. The absent slot must
+            % be skipped rather than producing an entry with an empty path,
+            % which the uploader would report as a missing file.
+            testCase.addSeriesDocument('series_upload_sparse', [1 3]);
+            manifest = testCase.listFiles();
+
+            names = {manifest.name};
+            testCase.verifyTrue(any(strcmp(names, [testCase.SeriesName '_1'])), ...
+                'present slot 1 should be listed');
+            testCase.verifyTrue(any(strcmp(names, [testCase.SeriesName '_3'])), ...
+                'present slot 3 should be listed');
+            testCase.verifyFalse(any(strcmp(names, [testCase.SeriesName '_2'])), ...
+                'absent slot 2 should not be listed');
+
+            for k = 1:numel(manifest)
+                testCase.verifyNotEmpty(manifest(k).file_path, ...
+                    'no manifest entry may have an empty file_path');
+            end
+        end
+
+        function testADocumentWithoutASeriesIsUnaffected(testCase)
+            % The ordinary path has to keep working: a plain document's file
+            % is listed exactly once, and no phantom member entries appear.
+            filePath = fullfile(testCase.DatasetPath, 'plain.ext');
+            fid = fopen(filePath, 'w');
+            fwrite(fid, uint8(1:32), 'uint8');
+            fclose(fid);
+
+            doc = ndi.document('demoNDI', ...
+                'base.name', 'plain_doc', ...
+                'demoNDI.value', 7, ...
+                'base.session_id', testCase.Dataset.id());
+            doc = doc.add_file('filename1.ext', filePath);
+            testCase.Dataset.database_add(doc);
+
+            manifest = testCase.listFiles();
+
+            matches = strcmp({manifest.name}, 'filename1.ext');
+            testCase.verifyEqual(sum(matches), 1, ...
+                'a plain document file should be listed exactly once');
+        end
+
+    end
+
+    methods (Access = private)
+        function entry = entryNamed(testCase, manifest, name)
+            index = find(strcmp({manifest.name}, name), 1);
+            testCase.assertNotEmpty(index, ...
+                ['no manifest entry named ' name]);
+            entry = manifest(index);
+        end
+    end
+end


### PR DESCRIPTION
The upload half of #956. A dataset containing a file series uploaded its **manifest and nothing else**, so the cloud held a document declaring N members with none of their bytes. The download then had nothing to fetch — which is what makes `FileSeriesRoundTripTest`'s download test fail on main today.

## A correction to #956: it named the wrong function

I wrote that the gap was in `ndi.cloud.upload.scanForUpload`. **It isn't.** That belongs to the older `uploadToNDICloud` path. `ndi.cloud.uploadDataset` goes through `ndi.cloud.sync.internal.uploadFilesForDatasetDocuments`, whose manifest comes from `ndi.database.internal.list_binary_files`.

Both walk `file_list` the same way and share the blind spot, but only the latter is on the live path, and it's the one changed here. Found by tracing the `"N files in the manifest"` line in the failing run's log back to its source instead of trusting my earlier reading. (`scanForUpload` also can't be the live path: it never sets `file_path`, which `zipForUpload` requires.)

## The blind spot

```matlab
if file_name(end)=='#'   % legacy: NAME1, NAME2, ...
    this_filename = sprintf('%s%d', file_name(1:end-1), j);
```

A new-style series records members in a binary manifest rather than in `file_list`, and names them `NAME_<i>` — with an underscore. It never matched, so the loop saw one ordinary file (the manifest) and stopped.

Members are now enumerated from the per-series record and resolved by name through the manifest, which `did.implementations.sqlitedb` has been able to do since VH-Lab/DID-matlab#183. An absent slot is skipped rather than producing an entry with an empty path (which the uploader reports as a missing file) — a sparse series is the case the mechanism exists for.

Member entries are preallocated to the slot count and trimmed, not grown one at a time: a lightsheet pyramid level is tens of thousands of members, and the manifest is the array whose size is the whole problem.

## Tests — no credentials, no network

`list_binary_files` takes a local dataset and reads it, so **the upload half is checkable in the fast workflow** rather than only in Cloud CI, where a failure costs ten minutes and a set of secrets. Five tests:

- the manifest file is still listed (control)
- every member is listed (the bug)
- each member carries its own uid, path and byte count — members are written at **deliberately different lengths**, so an entry pointing at the wrong member fails on size rather than passing
- a sparse series lists only its present slots, and no entry has an empty `file_path`
- a document with no series is unaffected

## What this does not do

It does not fix the download. With members in the cloud there is now something to fetch, but nothing yet reconstructs their locations on the way down, and VH-Lab/DID-matlab#185 still refuses to store a downloaded series document. Those remain open in #956 and need the design decision recorded there — including whether members are fetched eagerly or on demand.

So **Cloud CI will still fail here** on `testManifestSurvivesADownloadFromTheCloud`, exactly as it does on main.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VMPdbVkfEbjfEviv6dspHN

---
_Generated by [Claude Code](https://claude.ai/code/session_01VMPdbVkfEbjfEviv6dspHN)_