### PR TITLE
Read a series member's bytes back out of the cloud (#966)

### DIFF
--- a/src/ndi/+ndi/+cloud/+sync/+internal/updateFileInfoForLocalFiles.m
+++ b/src/ndi/+ndi/+cloud/+sync/+internal/updateFileInfoForLocalFiles.m
@@ -68,6 +68,37 @@ function document = updateFileInfoForLocalFiles(document, fileDirectory, cloudDa
             filename = originalFileInfo(i).name; % name for ingestion
             if isfile(file_location)
                 document = document.add_file(filename, file_location);
+
+                % A SERIES MANIFEST also keeps the cloud reference it came
+                % from, as a second location alongside the local copy.
+                %
+                % Its members are still on the cloud -- they are left there
+                % deliberately, so that opening a dataset does not drag down
+                % a 28,000-member series -- and a member has no location of
+                % its own. DID resolves one by handing the MANIFEST's
+                % location to the customFileHandler with the member's uid in
+                % the context, so that location is the only thing telling the
+                % handler where to look. With the local path alone,
+                % download_file_from_cloud is handed a path that does not
+                % start with 'ndic://' and raises
+                % NDI:Didsqlite:UnsupportedFileLocationType, which DID takes
+                % as a plain miss -- so every member of a downloaded series
+                % is unreadable, silently. See VH-Lab/NDI-matlab#966.
+                %
+                % The uid in the reference is the file's ORIGINAL uid, the
+                % one the cloud knows it by. add_file mints a fresh uid for
+                % this second location's own record, which is harmless: DID
+                % passes only the location STRING to the handler, and the
+                % member's uid comes from the context.
+                %
+                % Manifests only. Every other file is already here, and a
+                % second location on each would be rows to no purpose.
+                if strlength(cloudDatasetId) > 0 && document.isFileSeries(filename)
+                    % ndi.document.add_file recognizes 'ndic://' and supplies
+                    % ingest 0, delete_original 0, location_type 'ndicloud'.
+                    document = document.add_file(filename, ...
+                        sprintf('ndic://%s/%s', cloudDatasetId, file_uid));
+                end
             else
                 warning('Local file does not exist for document "%s"', ...
                     document.document_properties.base.id)

--- a/src/ndi/+ndi/+database/+implementations/+database/didsqlite.m
+++ b/src/ndi/+ndi/+database/+implementations/+database/didsqlite.m
@@ -166,13 +166,28 @@ function download_file_from_cloud(destPath, sourcePath, context)
     % CONTEXT is the per-call struct DID's dispatchCustomFileHandler passes
     % when a handler declares three or more inputs (DID-matlab#186): it
     % carries the caller's documentId and, for a series member, the
-    % series name. When present those are used to look the uid up in a
-    % per-document signed-URL cache -- one API round trip per DOCUMENT
-    % (or per fileSeries scope) instead of one per uid, closing DID
-    % #173's step 3 for the read path. Falls back to per-uid
+    % series name and the MEMBER'S OWN UID. When present those are used to
+    % look the uid up in a per-document signed-URL cache -- one API round
+    % trip per DOCUMENT (or per fileSeries scope) instead of one per uid,
+    % closing DID #173's step 3 for the read path. Falls back to per-uid
     % getFileDetails when no context is given or the batch call cannot
     % answer -- so a 2-arg handler-shaped caller, and any uid missing
     % from the batch response, still work.
+    %
+    % WHICH UID IS BEING ASKED FOR. On an ordinary file, SOURCEPATH names
+    % it and its uid is the one in the ndic:// reference. On a SERIES
+    % MEMBER it is not: a member has no location of its own, so DID passes
+    % the SERIES MANIFEST's location as SOURCEPATH and names the member in
+    % context.uid (DID-matlab#188), with context.seriesName marking that it
+    % is a member at all. Parsing the uid out of SOURCEPATH there
+    % fetches the manifest a second time and stores it under the member's
+    % uid, so every later read of that member returns the manifest --
+    % quietly, and forever. DID guards against exactly this, comparing what
+    % a handler returns against the manifest it already holds and refusing
+    % a match with DID:SQLITEDB:FileSeries:HandlerReturnedManifest, which is
+    % what this handler tripped on every member fetch before the context
+    % was read. So the member's uid comes from the context; every other
+    % call still takes it from sourcePath.
     %
     % Previously a nested function inside do_openbinarydoc. It is file-local so
     % that do_add can pass the same handler.
@@ -189,7 +204,26 @@ function download_file_from_cloud(destPath, sourcePath, context)
         % Try the per-document batch cache first. Empty documentId
         % (2-arg dispatch, or an older DID) makes this a no-op that
         % returns "".
-        [docId, seriesName] = readContext(context);
+        [docId, seriesName, contextUid] = readContext(context);
+
+        % Take the uid from the context only for a SERIES MEMBER, which is
+        % what a non-empty seriesName marks. There sourcePath's uid is
+        % definitively the wrong one -- it names the manifest -- so there is
+        % nothing to weigh.
+        %
+        % Deliberately not "prefer context.uid whenever it is present". On an
+        % ordinary file DID also passes a uid (its files-table row), and it
+        % should equal the one in the ndic:// location, since
+        % updateFileInfoForRemoteFiles builds that location out of
+        % locations(1).uid. Should. If the two ever disagreed, the ndic://
+        % one is the identifier the CLOUD was told about and the one a URL
+        % can be minted for, so the context's would be the wrong uid to ask
+        % with -- and this is the live download path for every file NDI
+        % fetches, not just series members. Confining the change to the case
+        % that is broken leaves the case that works alone.
+        if strlength(seriesName) > 0 && strlength(contextUid) > 0
+            ndiFileUid = char(contextUid);
+        end
         fileUrl = ndi.cloud.download.internal.batchSignedUrlLookup( ...
             string(cloudDatasetId), docId, seriesName, string(ndiFileUid));
 
@@ -216,18 +250,23 @@ function download_file_from_cloud(destPath, sourcePath, context)
     end
 end
 
-function [docId, seriesName] = readContext(context)
-    % Pull documentId and seriesName from the DID handler context, if
-    % either field is present. Missing values become "" so the batch
-    % lookup can treat them uniformly.
+function [docId, seriesName, uid] = readContext(context)
+    % Pull documentId, seriesName and uid from the DID handler context, if
+    % the fields are present. Missing values become "" so the batch
+    % lookup can treat them uniformly, and so the caller can test uid
+    % with strlength rather than a field check of its own.
     docId = "";
     seriesName = "";
+    uid = "";
     if isstruct(context)
         if isfield(context,'documentId') && ~isempty(context.documentId)
             docId = string(context.documentId);
         end
         if isfield(context,'seriesName') && ~isempty(context.seriesName)
             seriesName = string(context.seriesName);
+        end
+        if isfield(context,'uid') && ~isempty(context.uid)
+            uid = string(context.uid);
         end
     end
 end

--- a/tests/+ndi/+unittest/+cloud/FileSeriesRoundTripTest.m
+++ b/tests/+ndi/+unittest/+cloud/FileSeriesRoundTripTest.m
@@ -434,7 +434,7 @@ classdef FileSeriesRoundTripTest < matlab.unittest.TestCase
             % them.
             %
             % EXPECTED TO FAIL until VH-Lab/DID-matlab#188 lands, at the
-            % member reachability assertion below. A member carries no
+            % member open assertion below. A member carries no
             % location of its own, so seriesMemberPath resolves the manifest,
             % looks the member up in the local cache and returns a miss --
             % which is the state of a dataset that has just been downloaded.
@@ -476,41 +476,72 @@ classdef FileSeriesRoundTripTest < matlab.unittest.TestCase
                 "the series document did not come back from the cloud. " + msg);
             remoteDoc = remoteDocs{1};
 
-            % Reachability first, and slot by slot rather than in bulk. WHICH
-            % slots arrived separates "the members never uploaded" from "the
-            % members are on the cloud but cannot be reached from here", and
-            % those are different bugs with different owners: none reachable
-            % is DID-matlab#188, some reachable is a transfer that lost
-            % members and is NDI's.
-            present = false(1, testCase.MemberCount);
+            % A LOCAL-CACHE probe, and deliberately not a gate.
+            % database_existbinarydoc reports what is on this machine and
+            % does not retrieve: did.implementations.sqlitedb.check_exist_doc
+            % calls seriesMemberPath WITHOUT mayRetrieve, because it "must
+            % not go to the network to answer a question about local state".
+            % A member of a freshly downloaded dataset is therefore absent
+            % here even when it is perfectly fetchable, so all-false is the
+            % expected reading before anything opens a member and says
+            % nothing about whether this test should pass. Recorded because
+            % the transition -- absent before, present after -- is what shows
+            % the fetch actually happened rather than the bytes having been
+            % lying around.
+            cachedBefore = false(1, testCase.MemberCount);
             for i = 1:testCase.MemberCount
-                present(i) = downloaded.database_existbinarydoc(remoteDoc.id(), ...
-                    sprintf('chunkdata.bin_%d', i));
+                cachedBefore(i) = downloaded.database_existbinarydoc( ...
+                    remoteDoc.id(), sprintf('chunkdata.bin_%d', i));
             end
-            % mat2str renders an empty row as "zeros(1,0)", and the zero
-            % case is the one this line exists to report. The audience for
-            % these diagnostics is often not a MATLAB user -- see the
-            % Narrative property -- so spell it.
-            presentSlots = find(present);
-            if isempty(presentSlots)
-                slotsText = "none";
-            else
-                slotsText = join(string(presentSlots), ", ");
-            end
-            narrative(end+1) = "Members reachable in the downloaded dataset: " + ...
-                sum(present) + " of " + testCase.MemberCount + ", slots " + ...
-                slotsText + ".";
-            narrative(end+1) = "NONE reachable is VH-Lab/DID-matlab#188: a member " + ...
-                "has no location of its own, and nothing asks the customFileHandler " + ...
-                "for its bytes at open time. SOME reachable is not #188 -- the " + ...
-                "transfer lost members, and that is NDI's bug.";
-            testCase.Narrative = narrative;
-            msg = ndi.unittest.cloud.APIMessage(narrative, all(present), present, ...
-                matlab.net.http.ResponseMessage.empty, ...
-                "downloaded database_existbinarydoc, per member");
 
-            testCase.assertTrue(all(present), ...
-                "a series member of the downloaded dataset could not be reached. " + msg);
+            % Opening is what retrieves -- do_open_doc passes mayRetrieve, so
+            % this is the only call that asks the handler for a member. Each
+            % open is caught rather than allowed to throw: a member that
+            % cannot be fetched raises DID:SQLITEDB:open, and letting the
+            % first one abort the loop would throw away exactly the slot-by-
+            % slot picture this test exists to produce. WHICH slots came back
+            % separates bugs with different owners -- none is
+            % VH-Lab/DID-matlab#188 or the member fetch never reaching the
+            % handler, some is a transfer that lost members and is NDI's.
+            opened     = false(1, testCase.MemberCount);
+            openError  = strings(1, testCase.MemberCount);
+            memberBytes = cell(1, testCase.MemberCount);
+            for i = 1:testCase.MemberCount
+                memberName = sprintf('chunkdata.bin_%d', i);
+                try
+                    fobj = downloaded.database_openbinarydoc(remoteDoc, memberName);
+                    fid = fopen(fobj.fullpathfilename, 'rb');
+                    memberBytes{i} = fread(fid, inf, '*uint8')';
+                    fclose(fid);
+                    downloaded.database_closebinarydoc(fobj);
+                    opened(i) = true;
+                catch openME
+                    openError(i) = string(openME.identifier) + ": " + ...
+                        string(openME.message);
+                end
+            end
+
+            % mat2str renders an empty row as "zeros(1,0)", and the zero case
+            % is the one these lines exist to report. The audience for these
+            % diagnostics is often not a MATLAB user -- see the Narrative
+            % property -- so spell it.
+            narrative(end+1) = "Members already in the local cache before any " + ...
+                "open: " + localSlotList(cachedBefore) + " (all-false is expected " + ...
+                "here; exist_doc never retrieves).";
+            narrative(end+1) = "Members successfully opened: " + sum(opened) + ...
+                " of " + testCase.MemberCount + ", slots " + localSlotList(opened) + ".";
+            if any(~opened)
+                narrative(end+1) = "First open failure: " + openError(find(~opened, 1));
+            end
+            testCase.Narrative = narrative;
+            msg = ndi.unittest.cloud.APIMessage(narrative, all(opened), ...
+                struct('cachedBefore', cachedBefore, 'opened', opened, ...
+                       'firstError', openError(find(~opened, 1))), ...
+                matlab.net.http.ResponseMessage.empty, ...
+                "downloaded database_openbinarydoc, per member");
+
+            testCase.assertTrue(all(opened), ...
+                "a series member of the downloaded dataset could not be opened. " + msg);
 
             % The bytes, compared in full rather than by length. Setup gives
             % all four members the SAME 64 bytes' length and distinguishes
@@ -520,18 +551,23 @@ classdef FileSeriesRoundTripTest < matlab.unittest.TestCase
             % whole way through -- come back the right size and the wrong
             % file.
             for i = 1:testCase.MemberCount
-                memberName = sprintf('chunkdata.bin_%d', i);
-                fobj = downloaded.database_openbinarydoc(remoteDoc, memberName);
-                fid = fopen(fobj.fullpathfilename, 'rb');
-                got = fread(fid, inf, '*uint8')';
-                fclose(fid);
-                downloaded.database_closebinarydoc(fobj);
-
-                testCase.verifyEqual(got, testCase.MemberContent{i}, ...
+                testCase.verifyEqual(memberBytes{i}, testCase.MemberContent{i}, ...
                     sprintf(['member %d came back from the cloud with ' ...
                              'different bytes than were uploaded'], i));
             end
         end
 
+    end
+end
+
+function text = localSlotList(mask)
+    % Render a logical slot mask as "1, 3" or "none". mat2str would say
+    % "zeros(1,0)" for the empty case, which is the case that matters most
+    % here and the least readable thing to print.
+    slots = find(mask);
+    if isempty(slots)
+        text = "none";
+    else
+        text = join(string(slots), ", ");
     end
 end

--- a/tests/+ndi/+unittest/+cloud/FileSeriesRoundTripTest.m
+++ b/tests/+ndi/+unittest/+cloud/FileSeriesRoundTripTest.m
@@ -18,11 +18,17 @@ classdef FileSeriesRoundTripTest < matlab.unittest.TestCase
 %      copied into FileDir/<uid> and NAME_<i> resolves through the manifest,
 %      so a member now has bytes to upload. testMembersAreIngestedLocally
 %      checks that and no longer skips.
-%   3. DONE, and it turned out not to need series awareness at all. A member
-%      is uploaded by uid like any other file once the upload manifest names
-%      it, which VH-Lab/NDI-matlab#961 taught
-%      ndi.database.internal.list_binary_files to do, so the existing batch
-%      presign path signs members without knowing they belong to a series.
+%   3. HALF DONE, and it turned out not to need series awareness. A member
+%      is signed by uid like any other file once something names it, which
+%      VH-Lab/NDI-matlab#961 taught ndi.database.internal.list_binary_files
+%      to do for the UPLOAD -- proven, since members demonstrably reach the
+%      cloud now. The DOWNLOAD direction is unproven, and cannot be proven
+%      here yet: nothing has ever asked the cloud for a member's bytes, so
+%      no member uid has been through batchSignedUrlLookup on the way back.
+%      testMembersSurviveADownloadFromTheCloud is what will exercise it, and
+%      is blocked behind the read-side gap below. Do not read this item as
+%      "signing works"; read it as "signing has no reason to care, and the
+%      return half is untested".
 %
 % What remains is on the READ side: VH-Lab/DID-matlab#188. A series member
 % carries no location of its own, so a dataset freshly downloaded from the
@@ -307,9 +313,14 @@ classdef FileSeriesRoundTripTest < matlab.unittest.TestCase
             % ones that actually made the journey. It needs SyncFiles so the
             % file contents come down and not just the document records.
             %
-            % Members are still out of reach (see the class header, item 2),
-            % so this covers the manifest half only -- which is the half that
-            % is testable today, and the half a series reader hits first.
+            % This covers the MANIFEST half only, on purpose. The member
+            % half is testMembersSurviveADownloadFromTheCloud, below, which
+            % shares this test's shape and downloads its own copy. Keeping
+            % them apart costs a second download per run and buys a failure
+            % that says which half broke: a manifest that arrived intact
+            % while its members did not is a different bug from a manifest
+            % that came back altered, and the manifest is the half a series
+            % reader hits first.
 
             import matlab.unittest.fixtures.TemporaryFolderFixture
 
@@ -431,6 +442,13 @@ classdef FileSeriesRoundTripTest < matlab.unittest.TestCase
             % member in 'open' mode, given the series manifest's location and
             % the member's uid. That failure is the evidence for #188, so do
             % not skip or delete this test to make CI green.
+            %
+            % If it still fails AFTER #188 lands, the next suspect is the
+            % return half of class header item 3: a member uid has never been
+            % through batchSignedUrlLookup on the way back, because nothing
+            % has ever asked the cloud for a member's bytes. This test is the
+            % first thing that will. Read the per-member diagnostic below
+            % before assuming which of the two it is.
 
             import matlab.unittest.fixtures.TemporaryFolderFixture
 

--- a/tests/+ndi/+unittest/+cloud/FileSeriesRoundTripTest.m
+++ b/tests/+ndi/+unittest/+cloud/FileSeriesRoundTripTest.m
@@ -487,9 +487,19 @@ classdef FileSeriesRoundTripTest < matlab.unittest.TestCase
                 present(i) = downloaded.database_existbinarydoc(remoteDoc.id(), ...
                     sprintf('chunkdata.bin_%d', i));
             end
+            % mat2str renders an empty row as "zeros(1,0)", and the zero
+            % case is the one this line exists to report. The audience for
+            % these diagnostics is often not a MATLAB user -- see the
+            % Narrative property -- so spell it.
+            presentSlots = find(present);
+            if isempty(presentSlots)
+                slotsText = "none";
+            else
+                slotsText = join(string(presentSlots), ", ");
+            end
             narrative(end+1) = "Members reachable in the downloaded dataset: " + ...
                 sum(present) + " of " + testCase.MemberCount + ", slots " + ...
-                mat2str(find(present)) + ".";
+                slotsText + ".";
             narrative(end+1) = "NONE reachable is VH-Lab/DID-matlab#188: a member " + ...
                 "has no location of its own, and nothing asks the customFileHandler " + ...
                 "for its bytes at open time. SOME reachable is not #188 -- the " + ...

--- a/tests/+ndi/+unittest/+cloud/FileSeriesRoundTripTest.m
+++ b/tests/+ndi/+unittest/+cloud/FileSeriesRoundTripTest.m
@@ -14,22 +14,36 @@ classdef FileSeriesRoundTripTest < matlab.unittest.TestCase
 %      addFileSeries in VH-Lab/DID-matlab#178 gave ndi.document nothing.
 %      VH-Lab/NDI-matlab#940 made it a subclass, and the class-level
 %      assumption below now opens.
-%   2. OPEN. Member ingestion is deferred: addFileSeries records where
-%      members are but nothing yet copies them into FileDir/<uid> or gives
-%      them rows in the files table, so there is nothing to upload for a
-%      member. testMembersSurviveTheRoundTrip skips on this.
-%   3. OPEN. ndi-cloud-node does not enumerate series members when signing
-%      URLs.
+%   2. DONE. Member ingestion landed in VH-Lab/DID-matlab#183: members are
+%      copied into FileDir/<uid> and NAME_<i> resolves through the manifest,
+%      so a member now has bytes to upload. testMembersAreIngestedLocally
+%      checks that and no longer skips.
+%   3. DONE, and it turned out not to need series awareness at all. A member
+%      is uploaded by uid like any other file once the upload manifest names
+%      it, which VH-Lab/NDI-matlab#961 taught
+%      ndi.database.internal.list_binary_files to do, so the existing batch
+%      presign path signs members without knowing they belong to a series.
 %
-% The manifest half is testable ahead of (2) and (3), because the manifest is
-% an ordinary document file and travels like one. Note what that does and does
-% not buy: testManifestSurvivesTheRoundTrip, testDocumentReportsItsSeries and
-% testCurrentFileListDoesNotExpandTheSeries all upload and then assert against
-% LocalDataset, which is never re-downloaded, so they show the cloud ACCEPTS a
-% document carrying a series manifest and nothing more. Only
-% testManifestSurvivesADownloadFromTheCloud reads the series back out of the
-% cloud, and it is the one that would catch a manifest dropped, renamed or
-% altered in transit.
+% What remains is on the READ side: VH-Lab/DID-matlab#188. A series member
+% carries no location of its own, so a dataset freshly downloaded from the
+% cloud cannot fetch one. It has the manifest, and the manifest names its
+% members by uid, but nothing asks the caller's handler for those bytes --
+% did.implementations.sqlitedb.seriesMemberPath resolves the manifest, looks
+% the member up in the local cache, and reports a miss. The ndic:// locations
+% that ndi.cloud.sync.internal.reconstructSeriesIngestLocations builds do not
+% help here: they carry ingest = 0 (members stay on the cloud until wanted,
+% deliberately), and do_add_doc strips them before storing anyway, so by open
+% time the manifest is all there is to go on.
+%
+% READ THE TEST NAMES CAREFULLY, because most of them do less than they sound
+% like. testManifestSurvivesTheRoundTrip, testDocumentReportsItsSeries,
+% testCurrentFileListDoesNotExpandTheSeries and testMembersAreIngestedLocally
+% all upload and then assert against LocalDataset, which is never
+% re-downloaded -- they check the same bytes setup wrote to disk, which no
+% transfer can corrupt, and so establish only that the cloud ACCEPTS a
+% document carrying a series. Only the two ...FromTheCloud tests read anything
+% back out. See VH-Lab/NDI-matlab#966 for how a suite of five green tests
+% managed to prove nothing about a member's bytes.
 
     properties (Constant)
         DatasetNamePrefix = 'NDI_UNITTEST_FILE_SERIES_';
@@ -227,27 +241,41 @@ classdef FileSeriesRoundTripTest < matlab.unittest.TestCase
             testCase.Narrative = narrative;
         end
 
-        function testMembersSurviveTheRoundTrip(testCase)
-            % The whole point. Needs member ingestion (DID) and series-aware
-            % URL signing (ndi-cloud-node); until both land this skips rather
-            % than fails, and becomes live on its own once they do.
+        function testMembersAreIngestedLocally(testCase)
+            % Members are copied into FileDir/<uid> and readable back by their
+            % NAME_<i> names (VH-Lab/DID-matlab#183). It used to skip on that,
+            % since nothing ingested a member; the skip is gone.
+            %
+            % RENAMED from testMembersSurviveTheRoundTrip, which is what it
+            % was called for most of its life and is not what it does: it
+            % reads from LocalDataset, never re-downloaded, so the bytes it
+            % compares are the ones setup wrote to disk a moment earlier. No
+            % transfer happens between the write and the read, so nothing a
+            % server did could make this fail. The name is why the suite
+            % looked like it covered the cloud round trip for members when
+            % nothing did -- see VH-Lab/NDI-matlab#966, and
+            % testMembersSurviveADownloadFromTheCloud below for the real one.
+            %
+            % Still worth keeping. When the round-trip test fails, this one
+            % separates "the members were never ingested, so nothing was
+            % uploaded" from "they were ingested and something happened in
+            % transit", and those have different owners.
             narrative = testCase.Narrative;
-            narrative(end+1) = "Begin testMembersSurviveTheRoundTrip.";
-            narrative(end+1) = "This test skips until member ingestion lands " + ...
-                "(VH-Lab/DID-matlab#173). The gate below is a LOCAL check: nothing " + ...
-                "copies members into FileDir/<uid>, so there is nothing to upload " + ...
-                "and no cloud change can open it.";
+            narrative(end+1) = "Begin testMembersAreIngestedLocally.";
+            narrative(end+1) = "This is a LOCAL check: it reads back from " + ...
+                "LocalDataset, which is never re-downloaded. It says members " + ...
+                "were ingested, not that they survived the cloud.";
             testCase.Narrative = narrative;
 
             q = ndi.query('base.name', 'exact_string', 'test_series_doc');
             docs = testCase.LocalDataset.database_search(q);
             doc = docs{1};
 
-            testCase.assumeTrue(...
+            testCase.assertTrue(...
                 testCase.LocalDataset.database_existbinarydoc(doc.id(), 'chunkdata.bin_1'), ...
-                ['Series members are not ingested yet: addFileSeries records ' ...
-                 'where they are, but nothing copies them into FileDir/<uid> ' ...
-                 'or gives them a files-table row. See VH-Lab/DID-matlab#173.']);
+                ['Series members were not ingested: addFileSeries records ' ...
+                 'where they are, and VH-Lab/DID-matlab#183 is meant to copy ' ...
+                 'them into FileDir/<uid> and give them a files-table row.']);
 
             for i = 1:testCase.MemberCount
                 memberName = sprintf('chunkdata.bin_%d', i);
@@ -258,7 +286,7 @@ classdef FileSeriesRoundTripTest < matlab.unittest.TestCase
                 testCase.LocalDataset.database_closebinarydoc(fobj);
 
                 testCase.verifyEqual(got, testCase.MemberContent{i}, ...
-                    sprintf('member %d came back with different bytes', i));
+                    sprintf('member %d was ingested with different bytes', i));
             end
         end
 
@@ -382,6 +410,99 @@ classdef FileSeriesRoundTripTest < matlab.unittest.TestCase
                 "downloaded manifest uids differ from the ones uploaded; " + ...
                 "a member would resolve to the wrong file. " + msg);
             testCase.Narrative = narrative;
+        end
+
+        function testMembersSurviveADownloadFromTheCloud(testCase)
+            % THE acceptance test for the file series cloud path: the only
+            % thing anywhere that proves a member's BYTES made the journey.
+            % See VH-Lab/NDI-matlab#966 for why the suite was green without
+            % it -- every other test either reads from LocalDataset, which no
+            % transfer touches, or checks the manifest, which is an ordinary
+            % document file. A server that accepted the member uploads and
+            % then dropped, truncated or swapped their bytes passes all of
+            % them.
+            %
+            % EXPECTED TO FAIL until VH-Lab/DID-matlab#188 lands, at the
+            % member reachability assertion below. A member carries no
+            % location of its own, so seriesMemberPath resolves the manifest,
+            % looks the member up in the local cache and returns a miss --
+            % which is the state of a dataset that has just been downloaded.
+            % #188 adds the retrieval: the customFileHandler is called for the
+            % member in 'open' mode, given the series manifest's location and
+            % the member's uid. That failure is the evidence for #188, so do
+            % not skip or delete this test to make CI green.
+
+            import matlab.unittest.fixtures.TemporaryFolderFixture
+
+            narrative = testCase.Narrative;
+            narrative(end+1) = "Begin testMembersSurviveADownloadFromTheCloud.";
+            narrative(end+1) = "Reading each member's bytes from the DOWNLOADED " + ...
+                "copy, not from the local dataset they were written into.";
+
+            downloadFixture = testCase.applyFixture(TemporaryFolderFixture);
+            narrative(end+1) = "Downloading dataset " + testCase.DatasetID + ...
+                " with SyncFiles=true into a fresh folder.";
+            downloaded = ndi.cloud.downloadDataset(testCase.DatasetID, downloadFixture.Folder, ...
+                'SyncFiles', true, 'Verbose', false);
+            msg = ndi.unittest.cloud.APIMessage(narrative, ~isempty(downloaded), ...
+                "downloadDataset returned an ndi.dataset", ...
+                matlab.net.http.ResponseMessage.empty, "ndi.cloud.downloadDataset");
+            testCase.assertNotEmpty(downloaded, ...
+                "downloadDataset returned nothing for the uploaded dataset. " + msg);
+
+            q = ndi.query('base.name', 'exact_string', 'test_series_doc');
+            remoteDocs = downloaded.database_search(q);
+            msg = ndi.unittest.cloud.APIMessage(narrative, true, numel(remoteDocs), ...
+                matlab.net.http.ResponseMessage.empty, "downloaded database_search");
+            testCase.assertNumElements(remoteDocs, 1, ...
+                "the series document did not come back from the cloud. " + msg);
+            remoteDoc = remoteDocs{1};
+
+            % Reachability first, and slot by slot rather than in bulk. WHICH
+            % slots arrived separates "the members never uploaded" from "the
+            % members are on the cloud but cannot be reached from here", and
+            % those are different bugs with different owners: none reachable
+            % is DID-matlab#188, some reachable is a transfer that lost
+            % members and is NDI's.
+            present = false(1, testCase.MemberCount);
+            for i = 1:testCase.MemberCount
+                present(i) = downloaded.database_existbinarydoc(remoteDoc.id(), ...
+                    sprintf('chunkdata.bin_%d', i));
+            end
+            narrative(end+1) = "Members reachable in the downloaded dataset: " + ...
+                sum(present) + " of " + testCase.MemberCount + ", slots " + ...
+                mat2str(find(present)) + ".";
+            narrative(end+1) = "NONE reachable is VH-Lab/DID-matlab#188: a member " + ...
+                "has no location of its own, and nothing asks the customFileHandler " + ...
+                "for its bytes at open time. SOME reachable is not #188 -- the " + ...
+                "transfer lost members, and that is NDI's bug.";
+            testCase.Narrative = narrative;
+            msg = ndi.unittest.cloud.APIMessage(narrative, all(present), present, ...
+                matlab.net.http.ResponseMessage.empty, ...
+                "downloaded database_existbinarydoc, per member");
+
+            testCase.assertTrue(all(present), ...
+                "a series member of the downloaded dataset could not be reached. " + msg);
+
+            % The bytes, compared in full rather than by length. Setup gives
+            % all four members the SAME 64 bytes' length and distinguishes
+            % them by content, so a size check here would catch nothing at
+            % all: two members swapped by a uid mixup -- the failure this
+            % path is most prone to, since a member is addressed by uid the
+            % whole way through -- come back the right size and the wrong
+            % file.
+            for i = 1:testCase.MemberCount
+                memberName = sprintf('chunkdata.bin_%d', i);
+                fobj = downloaded.database_openbinarydoc(remoteDoc, memberName);
+                fid = fopen(fobj.fullpathfilename, 'rb');
+                got = fread(fid, inf, '*uint8')';
+                fclose(fid);
+                downloaded.database_closebinarydoc(fobj);
+
+                testCase.verifyEqual(got, testCase.MemberContent{i}, ...
+                    sprintf(['member %d came back from the cloud with ' ...
+                             'different bytes than were uploaded'], i));
+            end
         end
 
     end

--- a/tests/+ndi/+unittest/+cloud/TestDownloadedSeriesManifestKeepsItsCloudLocation.m
+++ b/tests/+ndi/+unittest/+cloud/TestDownloadedSeriesManifestKeepsItsCloudLocation.m
@@ -1,0 +1,204 @@
+classdef TestDownloadedSeriesManifestKeepsItsCloudLocation < matlab.unittest.TestCase
+% A downloaded series manifest must keep the cloud reference it came from.
+%
+% ndi.cloud.sync.internal.updateFileInfoForLocalFiles re-points a downloaded
+% document's files at the local copies that came down with it. For a FILE
+% SERIES that is not enough, and the gap is invisible until someone opens a
+% member.
+%
+% A series' members are deliberately left on the cloud -- that laziness is
+% the point, so that opening a dataset does not drag down a 28,000-member
+% series -- and a member has no location of its own. DID resolves one by
+% handing the MANIFEST's location to the customFileHandler with the member's
+% uid in the context (VH-Lab/DID-matlab#188), so the manifest's location is
+% the only thing telling the handler where to look.
+%
+% With the local path as its only location, the handler is given a path that
+% does not start with 'ndic://' and
+% ndi.database.implementations.database.didsqlite/download_file_from_cloud
+% raises NDI:Didsqlite:UnsupportedFileLocationType. DID treats a handler that
+% fails as a plain miss -- deliberately, since it resolves speculatively --
+% so every member of a downloaded series reads as absent and nothing says
+% why. See VH-Lab/NDI-matlab#966.
+%
+% So the manifest keeps both: the local copy, and the 'ndic://' reference
+% under the uid the cloud knows it by.
+%
+% Offline. This is the half of #966 that needs no credentials and no network,
+% and it is the half that was wrong.
+
+    properties (Constant)
+        SeriesName = 'chunkdata.bin';
+        CloudDatasetId = "6a9de57dab55fb610de803d5";
+    end
+
+    properties
+        Dataset
+        DatasetPath
+        FileDir
+    end
+
+    methods (TestMethodSetup)
+        function setupWorkingFolder(testCase)
+            testCase.applyFixture(matlab.unittest.fixtures.WorkingFolderFixture);
+            testCase.DatasetPath = fullfile(pwd, 'ds');
+            mkdir(testCase.DatasetPath);
+            % A dataset only so that base.session_id is a real id; nothing is
+            % added to it. The subject here is a document, not a database.
+            testCase.Dataset = ndi.dataset.dir('ds_manifest_location', testCase.DatasetPath);
+
+            testCase.FileDir = fullfile(pwd, 'downloaded_files');
+            mkdir(testCase.FileDir);
+        end
+    end
+
+    methods (TestMethodTeardown)
+        function closeDatabase(~)
+            try
+                mksqlite('close');
+            catch
+                % nothing open to close
+            end
+        end
+    end
+
+    methods (Access = private)
+        function doc = seriesDocument(testCase)
+            % A two-member series, then the state a SyncFiles download leaves
+            % behind: the manifest's bytes present in FileDir under its uid,
+            % the members nowhere on this machine.
+            memberDir = fullfile(pwd, 'members');
+            mkdir(memberDir);
+            memberPaths = cell(1, 2);
+            for i = 1:2
+                p = fullfile(memberDir, sprintf('member%d.bin', i));
+                fid = fopen(p, 'w');
+                fwrite(fid, uint8(1:(8 + i)), 'uint8');
+                fclose(fid);
+                memberPaths{i} = p;
+            end
+
+            doc = ndi.document('demoNDISeries', ...
+                'base.name', 'series_doc', ...
+                'demoNDISeries.value', 1, ...
+                'base.session_id', testCase.Dataset.id());
+            doc = doc.addFileSeries(testCase.SeriesName, memberPaths);
+
+            % The downloaded copy of the manifest, named by its uid, which is
+            % what updateFileInfoForLocalFiles looks for.
+            entry = testCase.entryNamed(doc, testCase.SeriesName);
+            copyfile(entry.locations(1).location, ...
+                fullfile(testCase.FileDir, entry.locations(1).uid));
+        end
+
+        function entry = entryNamed(testCase, doc, name)
+            fi = doc.document_properties.files.file_info;
+            idx = find(strcmp({fi.name}, name), 1);
+            testCase.assertNotEmpty(idx, ['no file_info entry named ' name]);
+            entry = fi(idx);
+        end
+
+        function loc = locationOfType(testCase, locations, wantedType)
+            types = {locations.location_type};
+            idx = find(strcmp(types, wantedType), 1);
+            testCase.assertNotEmpty(idx, ...
+                ['no location of type ' wantedType ' (have: ' ...
+                 strjoin(types, ', ') ')']);
+            loc = locations(idx);
+        end
+    end
+
+    methods (Test)
+
+        function testTheManifestKeepsItsLocalCopy(testCase)
+            % Control. The existing behaviour must survive: the manifest is
+            % here, and reading it must not require the network.
+            doc = testCase.seriesDocument();
+            out = ndi.cloud.sync.internal.updateFileInfoForLocalFiles( ...
+                doc, string(testCase.FileDir), testCase.CloudDatasetId);
+
+            entry = testCase.entryNamed(out, testCase.SeriesName);
+            local = testCase.locationOfType(entry.locations, 'file');
+            testCase.verifyTrue(isfile(local.location), ...
+                'the manifest''s local location should resolve to a real file');
+        end
+
+        function testTheManifestAlsoKeepsItsCloudReference(testCase)
+            % THE BUG (#966). Without this the handler is handed a local path
+            % it cannot resolve, and every member of the series is
+            % unreadable.
+            doc = testCase.seriesDocument();
+            % Two steps: indexing into a method's return value is not legal
+            % MATLAB.
+            beforeEntry = testCase.entryNamed(doc, testCase.SeriesName);
+            expectedUid = beforeEntry.locations(1).uid;
+
+            out = ndi.cloud.sync.internal.updateFileInfoForLocalFiles( ...
+                doc, string(testCase.FileDir), testCase.CloudDatasetId);
+
+            entry = testCase.entryNamed(out, testCase.SeriesName);
+            remote = testCase.locationOfType(entry.locations, 'ndicloud');
+
+            % The uid in the reference must be the one the CLOUD knows the
+            % manifest by -- its ORIGINAL uid, not the fresh one add_file
+            % mints for this location's own record. A reference built from
+            % the wrong uid would ask the cloud for a file that is not there.
+            testCase.verifyEqual(remote.location, ...
+                char(sprintf('ndic://%s/%s', testCase.CloudDatasetId, expectedUid)), ...
+                'the cloud reference names the wrong dataset or uid');
+
+            % An ndic:// location is fetched on demand, never ingested at add
+            % time and never deleted: that laziness is why the members stay
+            % on the cloud in the first place.
+            % double(): verifyEqual is strict about class, and these flags
+            % are written as 0/1 by more than one path.
+            testCase.verifyEqual(double(remote.ingest), 0, ...
+                'the cloud reference must not be ingested at add time');
+            testCase.verifyEqual(double(remote.delete_original), 0, ...
+                'the cloud reference must not be marked delete_original');
+        end
+
+        function testAPlainFileGetsNoCloudReference(testCase)
+            % Only manifests need one. Every other file came down with the
+            % dataset and is already here, so a second location on each would
+            % be rows to no purpose.
+            filePath = fullfile(pwd, 'plain.ext');
+            fid = fopen(filePath, 'w');
+            fwrite(fid, uint8(1:16), 'uint8');
+            fclose(fid);
+
+            doc = ndi.document('demoNDI', ...
+                'base.name', 'plain_doc', ...
+                'demoNDI.value', 7, ...
+                'base.session_id', testCase.Dataset.id());
+            doc = doc.add_file('filename1.ext', filePath);
+
+            entry = testCase.entryNamed(doc, 'filename1.ext');
+            copyfile(filePath, fullfile(testCase.FileDir, entry.locations(1).uid));
+
+            out = ndi.cloud.sync.internal.updateFileInfoForLocalFiles( ...
+                doc, string(testCase.FileDir), testCase.CloudDatasetId);
+
+            outEntry = testCase.entryNamed(out, 'filename1.ext');
+            testCase.verifyNumElements(outEntry.locations, 1, ...
+                'a plain file should keep exactly one location');
+            testCase.verifyEqual(outEntry.locations(1).location_type, 'file');
+        end
+
+        function testNoCloudDatasetIdMeansNoCloudReference(testCase)
+            % updateFileInfoForLocalFiles is also called without a cloud
+            % dataset id, and there is no reference to build then. It must
+            % leave the document as it found it rather than writing
+            % 'ndic:///<uid>'.
+            doc = testCase.seriesDocument();
+            out = ndi.cloud.sync.internal.updateFileInfoForLocalFiles( ...
+                doc, string(testCase.FileDir));
+
+            entry = testCase.entryNamed(out, testCase.SeriesName);
+            types = {entry.locations.location_type};
+            testCase.verifyFalse(any(strcmp(types, 'ndicloud')), ...
+                'no cloud dataset id was given, so no cloud reference is possible');
+        end
+
+    end
+end

--- a/tests/+ndi/+unittest/TestDownloadedSeriesManifestKeepsItsCloudLocation.m
+++ b/tests/+ndi/+unittest/TestDownloadedSeriesManifestKeepsItsCloudLocation.m
@@ -26,6 +26,14 @@ classdef TestDownloadedSeriesManifestKeepsItsCloudLocation < matlab.unittest.Tes
 %
 % Offline. This is the half of #966 that needs no credentials and no network,
 % and it is the half that was wrong.
+%
+% It lives in ndi.unittest, NOT ndi.unittest.cloud, for that reason:
+% testToolboxNoCloud drops every class whose name starts
+% 'ndi.unittest.cloud.', so a test placed there runs only in the slow,
+% credentialed Cloud suite no matter how offline it is. The other offline
+% tests of cloud internals -- ReconstructSeriesIngestLocationsTest,
+% BatchSignedUrlLookupTest, SignedURLSetMockTest -- are here for the same
+% reason.
 
     properties (Constant)
         SeriesName = 'chunkdata.bin';

--- a/tools/tasks/testCloudApiDev.m
+++ b/tools/tasks/testCloudApiDev.m
@@ -1,0 +1,18 @@
+function testCloudApiDev(varargin)
+%testCloudApiDev Run the cloud tests against the dev environment.
+%
+%   This forces CLOUD_API_ENVIRONMENT=dev and runs every test in
+%   tests/+ndi/+unittest/+cloud, against https://dev-api.ndi-cloud.com/v1.
+%   The sibling of testCloudApiProd, for the case where an API change is
+%   deployed to dev and not yet to prod.
+%
+%   The scheduled "Test NDI Cloud Api" workflow already covers both
+%   environments as a matrix. This exists for running dev by hand, locally
+%   or with workflow_dispatch, without editing an environment variable and
+%   remembering to put it back.
+%
+%   See also: testCloudApiProd, testFileSeriesCloud, ndi.cloud.api.url
+
+    setenv("CLOUD_API_ENVIRONMENT", "dev")
+    testCloudApi(varargin{:})
+end

--- a/tools/tasks/testFileSeriesCloud.m
+++ b/tools/tasks/testFileSeriesCloud.m
@@ -1,0 +1,74 @@
+function results = testFileSeriesCloud(environment, className)
+%testFileSeriesCloud Run one cloud test class against one API environment.
+%
+%   testFileSeriesCloud() runs ndi.unittest.cloud.FileSeriesRoundTripTest
+%   against the DEV API.
+%
+%   testFileSeriesCloud("prod") runs it against prod instead.
+%
+%   testFileSeriesCloud(ENV, CLASSNAME) runs any cloud test class.
+%
+%   Why this exists rather than testCloudApiDev: the whole cloud suite takes
+%   several minutes and creates, uploads to and deletes a dataset per test
+%   method. When the question is one class -- "does a series member survive
+%   the round trip against the API I just deployed?" -- everything else is
+%   wall time and synthetic datasets in someone's organization.
+%
+%   BEFORE RUNNING, set your credentials:
+%
+%       setenv NDI_CLOUD_USERNAME  you@example.com
+%       setenv NDI_CLOUD_PASSWORD  ...
+%
+%   Without them the cloud tests SKIP themselves -- the class-level
+%   assumption in FileSeriesRoundTripTest reports Incomplete, not Failed --
+%   so a credential-less run looks quiet rather than wrong. This function
+%   refuses to start instead of letting that happen.
+%
+%   The environment is left set on exit, deliberately: a later run in the
+%   same MATLAB session should not silently go somewhere else. Clear it with
+%   setenv('CLOUD_API_ENVIRONMENT','') to return to the prod default.
+%
+%   See also: testCloudApiDev, testCloudApiProd, ndi.cloud.api.url
+
+    arguments
+        environment (1,1) string {mustBeMember(environment, ["dev", "prod"])} = "dev"
+        className   (1,1) string = "ndi.unittest.cloud.FileSeriesRoundTripTest"
+    end
+
+    import matlab.unittest.TestSuite
+    import matlab.unittest.TestRunner
+
+    requiredVars = ["NDI_CLOUD_USERNAME", "NDI_CLOUD_PASSWORD"];
+    for i = 1:numel(requiredVars)
+        if isempty(getenv(requiredVars(i)))
+            error('NDI:Test:MissingCloudCredential', ...
+                ['%s is not set. The cloud tests skip themselves without ' ...
+                 'credentials and report Incomplete rather than Failed, ' ...
+                 'which reads like success. Set it and run again.'], ...
+                requiredVars(i));
+        end
+    end
+
+    setenv("CLOUD_API_ENVIRONMENT", char(environment))
+
+    projectRootDir = nditools.projectdir();
+    nditools.installRequirements(fullfile(projectRootDir, 'tests'))
+
+    fprintf('Running %s against the %s API.\n', className, environment);
+
+    suite = TestSuite.fromClass(meta.class.fromName(char(className)));
+    runner = TestRunner.withTextOutput('OutputDetail', 'Detailed');
+    results = runner.run(suite);
+    display(results)
+
+    % Incomplete is worth calling out separately from Failed: it means the
+    % tests never ran (a class-level assumption closed), which no failure
+    % count will tell you.
+    if any([results.Incomplete])
+        warning('NDI:Test:IncompleteCloudRun', ...
+            ['%d of %d tests were Incomplete -- they did not run. That is ' ...
+             'an assumption closing, not a failure; check credentials and ' ...
+             'the class-level assumptions before reading the result.'], ...
+            sum([results.Incomplete]), numel(results));
+    end
+end


### PR DESCRIPTION
Fixes #966.

**A file series member's bytes now make the full round trip, and something checks that they do.** Cloud CI 1 at `504c5bc`: **62 passed, 0 failed, 0 incomplete** — the partition holding `FileSeriesRoundTripTest`, which had been red on every prior run of this branch.

The earlier do-not-merge warning is gone: it applied while this PR was deliberately red pending VH-Lab/DID-matlab#188, which has since merged along with DID#191.

## The problem

`FileSeriesRoundTripTest` had five passing tests and did not establish that a member's bytes survive the trip to the cloud and back.

`testMembersSurviveTheRoundTrip` was named for a round trip and asserted against `testCase.LocalDataset`, which is never re-downloaded — it compared the same bytes setup had written to disk a moment earlier, with no transfer in between. The only test that downloaded, `testManifestSurvivesADownloadFromTheCloud`, read the manifest and the counts. So a server that accepted the member uploads and then dropped, truncated, or swapped their bytes passed the entire class. That is how #961 (upload enumerates members) and #959 (download reconstructs locations) both went green with nothing having shown a member makes it there and back.

## What is here

**The test.** `testMembersSurviveADownloadFromTheCloud` downloads into a fresh folder and, for every member: opens it on the **downloaded** dataset and compares its bytes **in full**. Setup gives all four members the same 64-byte length and distinguishes them by content, so a size check would catch nothing — and a uid mixup, the failure this path is most prone to, produces a right-sized wrong file.

Each open is caught per slot rather than allowed to abort the loop, because *which* members came back separates bugs with different owners. The `exist_doc` probe is recorded as a diagnostic, not a gate: `check_exist_doc` calls `seriesMemberPath` without `mayRetrieve` by design, so a downloaded member reads as absent there even when perfectly fetchable. Asserting on it would have reported a working feature as a DID bug.

**Two source fixes**, both found by running that test rather than by reading:

1. `download_file_from_cloud` took the uid from the `ndic://` sourcePath. For a member that path names the **manifest**, so it fetched the manifest again and would have cached it under the member's uid — every later read of that member returning the manifest, quietly and permanently. DID's `HandlerReturnedManifest` guard caught it, which is why nothing was ever corrupted while the repos were out of step. `readContext` now returns `uid` and a member fetch uses it, only when `seriesName` marks it as a member: DID passes a uid on ordinary opens too, and the `ndic://` uid is the only identifier the cloud can mint a URL for.

2. A downloaded series manifest now keeps **both** locations — the local copy and the `ndic://` reference under the uid the cloud knows it by. DID#191 made DID offer a locally-synced manifest to the handler, which was necessary but not sufficient: the location it offers is a local path, and `download_file_from_cloud` raises `UnsupportedFileLocationType` for anything that is not `ndic://`. DID treats a failing handler as a plain miss, so members stayed unreadable and Cloud CI failed *identically* before and after #191 landed.

**Offline coverage** for that second fix, in `TestDownloadedSeriesManifestKeepsItsCloudLocation`: the local copy survives, the reference carries the original uid and is lazy (`ingest` 0, `delete_original` 0), a plain file gets no second location, and no cloud dataset id yields no reference rather than `ndic:///<uid>`.

**Dev-environment runners.** `testCloudApiProd` had no dev sibling; `testCloudApiDev` mirrors it, and `testFileSeriesCloud` runs one cloud class against a chosen environment (default: the file series round trip against dev). It refuses to start without credentials, because without them the cloud tests skip themselves and report Incomplete rather than Failed — a quiet run that reads like success.

**Housekeeping.** `testMembersSurviveTheRoundTrip` → `testMembersAreIngestedLocally`, which is what it does, with its stale skip gate dropped (member ingestion landed in DID#183). The class header, which still listed member ingestion and series-aware URL signing as outstanding, now says which tests read from the cloud and which do not — the naming is what hid this.

## What this still does not prove

A green run does **not** show the batch presign path was used. `batchSignedUrlLookup` returns `""` on any failure and `download_file_from_cloud` falls back to per-uid `getFileDetails`, which resolves members perfectly well. And the `fileSeries` scope is a scale property — at four members, scoped and unscoped are both correct and both fast, so no assertion at this size can tell them apart. Filed as #968.

## Status

Cloud CI 1 and 2 green at `504c5bc`; CI 3 still running. The head `5cca2f7` adds only the two task files under `tools/tasks/`, which no test path touches. Code Analyzer and symmetry green on the head.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VMPdbVkfEbjfEviv6dspHN