### PR TITLE
Correct two class headers that #969 falsified

### DIFF
--- a/tests/+ndi/+unittest/+cloud/FileSeriesRoundTripTest.m
+++ b/tests/+ndi/+unittest/+cloud/FileSeriesRoundTripTest.m
@@ -18,28 +18,32 @@ classdef FileSeriesRoundTripTest < matlab.unittest.TestCase
 %      copied into FileDir/<uid> and NAME_<i> resolves through the manifest,
 %      so a member now has bytes to upload. testMembersAreIngestedLocally
 %      checks that and no longer skips.
-%   3. HALF DONE, and it turned out not to need series awareness. A member
-%      is signed by uid like any other file once something names it, which
+%   3. DONE, and it turned out not to need series awareness. A member is
+%      signed by uid like any other file once something names it, which
 %      VH-Lab/NDI-matlab#961 taught ndi.database.internal.list_binary_files
-%      to do for the UPLOAD -- proven, since members demonstrably reach the
-%      cloud now. The DOWNLOAD direction is unproven, and cannot be proven
-%      here yet: nothing has ever asked the cloud for a member's bytes, so
-%      no member uid has been through batchSignedUrlLookup on the way back.
-%      testMembersSurviveADownloadFromTheCloud is what will exercise it, and
-%      is blocked behind the read-side gap below. Do not read this item as
-%      "signing works"; read it as "signing has no reason to care, and the
-%      return half is untested".
+%      to do for the UPLOAD. The DOWNLOAD direction closed later and took
+%      three separate fixes to get there, which is why this item spent a
+%      while reading "half done": DID-matlab#188 gave the manifest a way to
+%      ask a handler for a member's bytes, DID-matlab#191 made that work
+%      when the manifest also carries a local path, and VH-Lab/NDI-matlab#968
+%      found that the batch presign call had been addressing documents by
+%      the wrong id namespace since #952 -- so it 404'd every time and the
+%      per-uid fallback silently did the work.
 %
-% What remains is on the READ side: VH-Lab/DID-matlab#188. A series member
-% carries no location of its own, so a dataset freshly downloaded from the
-% cloud cannot fetch one. It has the manifest, and the manifest names its
-% members by uid, but nothing asks the caller's handler for those bytes --
-% did.implementations.sqlitedb.seriesMemberPath resolves the manifest, looks
-% the member up in the local cache, and reports a miss. The ndic:// locations
-% that ndi.cloud.sync.internal.reconstructSeriesIngestLocations builds do not
-% help here: they carry ingest = 0 (members stay on the cloud until wanted,
-% deliberately), and do_add_doc strips them before storing anyway, so by open
-% time the manifest is all there is to go on.
+% The read side is now closed. A member's bytes make the full round trip:
+% testMembersSurviveADownloadFromTheCloud reads them out of a freshly
+% downloaded dataset, and testTheBatchScopeIsTheSeriesAndNotTheWholeDocument
+% additionally requires that they arrived through ONE scoped batch presign
+% call rather than one call per member. Both pass against production.
+%
+% For the record, since the shape of the old gap explains the design: a
+% series member carries no location of its own, so a downloaded dataset has
+% only the manifest, which names members by uid. The ndic:// locations that
+% ndi.cloud.sync.internal.reconstructSeriesIngestLocations builds carry
+% ingest = 0 (members stay on the cloud until wanted, deliberately), and
+% do_add_doc strips them before storing -- so by open time the manifest
+% really is all there is, and fetching a member has to go through the
+% handler DID-matlab#188 added.
 %
 % READ THE TEST NAMES CAREFULLY, because most of them do less than they sound
 % like. testManifestSurvivesTheRoundTrip, testDocumentReportsItsSeries,
@@ -47,9 +51,10 @@ classdef FileSeriesRoundTripTest < matlab.unittest.TestCase
 % all upload and then assert against LocalDataset, which is never
 % re-downloaded -- they check the same bytes setup wrote to disk, which no
 % transfer can corrupt, and so establish only that the cloud ACCEPTS a
-% document carrying a series. Only the two ...FromTheCloud tests read anything
-% back out. See VH-Lab/NDI-matlab#966 for how a suite of five green tests
-% managed to prove nothing about a member's bytes.
+% document carrying a series. Only the three tests that download read
+% anything back out: the two ...FromTheCloud tests and the batch scope test.
+% See VH-Lab/NDI-matlab#966 for how a suite of five green tests managed to
+% prove nothing about a member's bytes.
 
     properties (Constant)
         DatasetNamePrefix = 'NDI_UNITTEST_FILE_SERIES_';

--- a/tests/+ndi/+unittest/SignedURLSetMockTest.m
+++ b/tests/+ndi/+unittest/SignedURLSetMockTest.m
@@ -1,17 +1,17 @@
 classdef SignedURLSetMockTest < matlab.unittest.TestCase
 % SIGNEDURLSETMOCKTEST - the signed-url-set sequencing logic, against mocks.
 %
-% ndi-cloud-node does not serve file-series members yet (see
-% VH-Lab/NDI-matlab#939), so there is no live endpoint to test the interesting
-% behaviour against: following a cursor, merging pages, refusing a cursor that
-% does not advance, polling a job to a terminal state, timing out, and
-% decompressing a result blob.
+% The endpoint is live now -- ndi-cloud-node serves file-series members, and
+% SignedURLSetTest and FileSeriesRoundTripTest exercise it under
+% tests/+ndi/+unittest/+cloud -- but the interesting behaviours here are ones
+% a working server will not produce on demand: a cursor that does not advance,
+% a job that never reaches a terminal state, a timeout, a truncated or
+% mis-shaped result blob.
 %
-% Those are exercised here through the fetchPage / pollStatus / downloadTo
-% seams, using the scripted doubles in ndi.test.helper. When the endpoint is
-% real, the same behaviours get a live counterpart under
-% tests/+ndi/+unittest/+cloud; these stay, because a mock is the only way to
-% produce a server that pages badly or a job that never finishes.
+% So these stay, and are the only coverage of those paths. They run through
+% the fetchPage / pollStatus / downloadTo seams against the scripted doubles
+% in ndi.test.helper. A live test can show the happy path works; only a mock
+% can show what happens when it does not.
 
     methods
         function page = makePage(~, uidUrlPairs, nextCursor)


### PR DESCRIPTION
Comments only. No executable line changes — `git diff` touches nothing but `%` lines in two test classes.

Both headers described the world as it was before last night, and both are now read by someone looking at a test that does the thing the header says is impossible. That is the same failure mode #966 was about, one layer down: documentation that cannot fail.

## `FileSeriesRoundTripTest`

Item 3 of the class header said the DOWNLOAD direction was unproven and *"cannot be proven here yet"*, blocked behind DID-matlab#188, with an instruction not to read it as "signing works".

It closed, and took three fixes to get there — worth naming, because no one of them would have been enough:

- **DID-matlab#188** gave the manifest a way to ask a handler for a member's bytes;
- **DID-matlab#191** made that work when the manifest also carries a local path;
- **#969** found the batch presign call had been addressing documents by the wrong id namespace since #952, so it 404'd every time and the per-uid fallback silently covered for it.

`testMembersSurviveADownloadFromTheCloud` and `testTheBatchScopeIsTheSeriesAndNotTheWholeDocument` both pass against production. The old gap is kept in the header as history, not deleted, because its shape is why fetching a member has to go through a handler at all — delete the explanation and the design looks arbitrary.

Also corrected there: *"only the two `...FromTheCloud` tests read anything back out"* is now three. The batch scope test downloads too.

## `SignedURLSetMockTest`

Said ndi-cloud-node does not serve file-series members, so there was no live endpoint to test against. There is, and `SignedURLSetTest` and `FileSeriesRoundTripTest` use it.

Rewritten to say why the mocks still earn their place rather than reading as leftovers: a working server will not produce a cursor that fails to advance, a job that never reaches a terminal state, a timeout, or a truncated result blob on request. Those paths have no live counterpart and never will — these are their only coverage.

## On CI

Nothing here needs testing. The workflows' `paths-ignore` covers `*.md` but not `.m`, so all three fire anyway.

Letting **No Cloud** run is worth it — it confirms both classes still parse and collect, and the test count should read exactly 1295 as on `0bcb63a56`. **Cloud Prod** creates and deletes datasets against the production API for ~20 minutes and can tell you nothing about a comment. If you want to spare it, cancel that run while it is still queued; cancelling it mid-run is the case the workflow's `cancel-in-progress: false` exists to prevent, since a SIGKILLed runner orphans synthetic datasets.

Follows #969.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VMPdbVkfEbjfEviv6dspHN

---
_Generated by [Claude Code](https://claude.ai/code/session_01VMPdbVkfEbjfEviv6dspHN)_