### PR TITLE
Pin openMINDS_MATLAB to v0.11.0, fix renamed base class

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -11,4 +11,4 @@ https://github.com/Waltham-Data-Science/NDI-compress-matlabp
 https://github.com/Waltham-Data-Science/ndi-ontology-matlab
 https://github.com/VH-Lab/pyraview
 https://github.com/bastibe/Violinplot-Matlab
-fex://134212-openminds-metadata-models-for-matlab
+fex://134212-openminds-metadata-models-for-matlab/0.11.0

--- a/src/ndi/+ndi/+database/+fun/openMINDSobj2struct.m
+++ b/src/ndi/+ndi/+database/+fun/openMINDSobj2struct.m
@@ -15,7 +15,6 @@ function [s] = openMINDSobj2struct(openmindsObj, cachekey)
 
     ndi_cache = ndi.common.getCache();
 
-    openminds_base_class = 'openminds.Node';
     cachetype = 'openmindsconversionstack';
 
     initial_call = 0;
@@ -84,7 +83,7 @@ function [s] = openMINDSobj2struct(openmindsObj, cachekey)
             if isa(f, 'datetime')
                 f = char(f);
             end
-            if openminds.utility.isInstance(f) | openminds.utility.isMixedInstance(f)
+            if openminds.utility.isInstance(f) || openminds.utility.isMixedInstance(f)
                 fields_here = {};
                 for k=1:numel(f)
                     if openminds.utility.isMixedInstance(f)

--- a/src/ndi/+ndi/+database/+fun/openMINDSobj2struct.m
+++ b/src/ndi/+ndi/+database/+fun/openMINDSobj2struct.m
@@ -15,7 +15,7 @@ function [s] = openMINDSobj2struct(openmindsObj, cachekey)
 
     ndi_cache = ndi.common.getCache();
 
-    openminds_base_class = 'openminds.abstract.Schema';
+    openminds_base_class = 'openminds.Node';
     cachetype = 'openmindsconversionstack';
 
     initial_call = 0;
@@ -85,7 +85,7 @@ function [s] = openMINDSobj2struct(openmindsObj, cachekey)
                 f = char(f);
             end
             mt = startsWith(class(f),'openminds.internal.mixedtype');
-            if isa(f,'openminds.abstract.Schema') | mt
+            if isa(f,'openminds.Node') | mt
                 fields_here = {};
                 for k=1:numel(f)
                     if mt

--- a/src/ndi/+ndi/+database/+fun/openMINDSobj2struct.m
+++ b/src/ndi/+ndi/+database/+fun/openMINDSobj2struct.m
@@ -85,7 +85,7 @@ function [s] = openMINDSobj2struct(openmindsObj, cachekey)
                 f = char(f);
             end
             mt = openminds.utility.isMixedInstance(f);
-            if isa(f,'openminds.Node') | mt
+            if openminds.utility.isInstance(f) | mt
                 fields_here = {};
                 for k=1:numel(f)
                     if mt

--- a/src/ndi/+ndi/+database/+fun/openMINDSobj2struct.m
+++ b/src/ndi/+ndi/+database/+fun/openMINDSobj2struct.m
@@ -84,7 +84,7 @@ function [s] = openMINDSobj2struct(openmindsObj, cachekey)
             if isa(f, 'datetime')
                 f = char(f);
             end
-            mt = startsWith(class(f),'openminds.internal.mixedtype');
+            mt = openminds.utility.isMixedInstance(f);
             if isa(f,'openminds.Node') | mt
                 fields_here = {};
                 for k=1:numel(f)

--- a/src/ndi/+ndi/+database/+fun/openMINDSobj2struct.m
+++ b/src/ndi/+ndi/+database/+fun/openMINDSobj2struct.m
@@ -84,11 +84,10 @@ function [s] = openMINDSobj2struct(openmindsObj, cachekey)
             if isa(f, 'datetime')
                 f = char(f);
             end
-            mt = openminds.utility.isMixedInstance(f);
-            if openminds.utility.isInstance(f) | mt
+            if openminds.utility.isInstance(f) | openminds.utility.isMixedInstance(f)
                 fields_here = {};
                 for k=1:numel(f)
-                    if mt
+                    if openminds.utility.isMixedInstance(f)
                         f_here = f(k).Instance;
                     else
                         f_here = f(k);

--- a/tests/+ndi/+symmetry/requirements.txt
+++ b/tests/+ndi/+symmetry/requirements.txt
@@ -5,4 +5,4 @@ https://github.com/a-ma72/mksqlite@master
 https://github.com/VH-lab/vhlab-thirdparty-matlab@master
 https://github.com/Waltham-Data-Science/NDI-compress-matlabp
 https://github.com/Waltham-Data-Science/ndi-ontology-matlab
-https://github.com/openMetadataInitiative/openMINDS_MATLAB
+fex://134212-openminds-metadata-models-for-matlab/0.11.0

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -5,4 +5,4 @@ https://github.com/a-ma72/mksqlite@master
 https://github.com/VH-lab/vhlab-thirdparty-matlab@master
 https://github.com/Waltham-Data-Science/NDI-compress-matlabp
 https://github.com/Waltham-Data-Science/ndi-ontology-matlab
-https://github.com/openMetadataInitiative/openMINDS_MATLAB
+fex://134212-openminds-metadata-models-for-matlab/0.11.0


### PR DESCRIPTION
## Summary

openMINDS_MATLAB v0.11.0 renamed `openminds.abstract.Schema` to `openminds.Node` with no compatibility shim (confirmed against the project's own migration guide, `docs/migration/v0.11.0.md`). NDI's dependency on openMINDS_MATLAB was unversioned (a bare FEX reference in `requirements.txt`, and a branch-tracking GitHub URL in the test requirement files), so an upgrade could silently break metadata document serialization at any time.

`ndi.database.fun.openMINDSobj2struct` hardcoded the old class name and used it to detect nested openMINDS objects when flattening an object graph into NDI documents. Since `isa()` against a nonexistent class name returns `false` rather than erroring, this failure mode is silent: child objects (e.g. a `Strain` linked from a `Species`, or a license linked from a dataset) stop being converted into linked `ndi://<id>` document references and get shoved directly into a document field instead, corrupting metadata rather than throwing a visible error. This sits in the path used by `subjectMaker.m` for every subject's species/strain/sex documents, and by the CrossRef license-conversion path.

The same file also detected instances and "mixed type" property values via `isa`/class-name checks that name openMINDS internals directly rather than going through openMINDS_MATLAB's own public utility functions for exactly this purpose - functions the toolbox's own internals use for the same checks.

## Changes

- `src/ndi/+ndi/+database/+fun/openMINDSobj2struct.m`:
  - `openminds.abstract.Schema` → `openminds.Node`, then further replaced with `openminds.utility.isInstance(f)` (openMINDS_MATLAB's own public wrapper for `isa(value, 'openminds.Node')`)
  - `startsWith(class(f), 'openminds.internal.mixedtype')` → `openminds.utility.isMixedInstance(f)` (the public wrapper for `isa(value, 'openminds.base.MixedTypeSet')`; `openminds.base.MixedTypeSet`'s own docstring says the internal mixedtype classes are "an implementation detail; do not name them" and points at this function)
- `requirements.txt`, `tests/requirements.txt`, `tests/+ndi/+symmetry/requirements.txt`: pin openMINDS_MATLAB to `fex://134212-openminds-metadata-models-for-matlab/0.11.0`, verified against the FEX registry API and against MatBox's own URI-parsing logic (`+matbox/+setup/installFromSourceUri.m`)

The two test requirement files previously used the raw GitHub URL with no ref, which tracks the default branch. They're switched to the versioned FEX URI instead, since MatBox's GitHub installer only downloads `archive/refs/heads/<ref>.zip` - it has no support for pinning to a tag (verified: `archive/refs/heads/v0.11.0.zip` 404s, since `v0.11.0` is a tag, not a branch).

I swept the rest of the codebase for every other API renamed or removed in openMINDS_MATLAB v0.10.0/v0.11.0 (`openminds.internal.abstract`, `openminds.constant.LATEST_VERSION`, `openminds.utility.isEmbeddedType`, `openminds.enum.Types.create`, `getUnresolvedLinks`/`processInstances`/`postProcessInstances`/`getSemanticIRI`, `getSchemaName`, `LinkResolverRegistry.instance`, `selectOpenMindsVersion`, etc.) - `openMINDSobj2struct.m` was the only file affected.

## Verification

Ran `tests/+ndi/+unittest/+setup/+NDIMaker/testSubjectMaker.m` in MATLAB with openMINDS_MATLAB v0.11.0 actually on the path (confirmed via `openminds.toolboxversion` and `which('openminds.Node')`): 11 passed, 4 failed, unchanged across all three commits. The 4 failures are a pre-existing `did.database/add_docs` argument-name mismatch from an unrelated local DID-matlab checkout and are unaffected by this PR - the tests exercising the fixed code path (`testMakeSubjectDocs_*`, which goes through `subjectMaker` → `openMINDSobj2ndi_document` → `openMINDSobj2struct`) all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)